### PR TITLE
Support capybara 2.3 as well as earlier versions

### DIFF
--- a/ae_page_objects.gemspec
+++ b/ae_page_objects.gemspec
@@ -18,6 +18,6 @@ Gem::Specification.new do |s|
   
   s.files                     = `git ls-files -- lib`.split("\n")
 
-  s.add_dependency('capybara', ['>= 1.1', '< 2.3'])
+  s.add_dependency('capybara', ['>= 1.1', '<= 2.3'])
 end
 


### PR DESCRIPTION
Trying to figure out why this was changed. Poltergeist explicitly depends on Capybara 2.3.0, therefore bundler will not install the latest version for me due to conflicting dependencies. Can we change it to this?
