### PR TITLE
Wrapped Capybara::ElementNotFound error in AePageObjects::LoadingElementFailed

### DIFF
--- a/README.md
+++ b/README.md
@@ -344,7 +344,7 @@ will fail:
 
 ```ruby
 login_page = LoginPage.new
-AePageObjects::LoadingFailed: MyPageObjects::LoginPage cannot be loaded with url '/dashboard/statistics'
+AePageObjects::LoadingPageFailed: MyPageObjects::LoginPage cannot be loaded with url '/dashboard/statistics'
   test/selenium/login_test.rb:16:in `new'
 ```
 
@@ -399,7 +399,7 @@ private
 
     # do custom load ensuring
     unless current_url =~ /\?debug\=true/
-      raise AePageObjects::LoadingFailed, "Should be in debug mode"
+      raise AePageObjects::LoadingPageFailed, "Should be in debug mode"
     end
   end
 end
@@ -408,7 +408,7 @@ end
 If you choose to override `ensure_loaded!` you:
 
 - need to call super() to get the default load ensuring
-- should raise `AePageObjects::LoadingFailed` if the document should not be loaded.
+- should raise `AePageObjects::LoadingPageFailed` if the document should not be loaded.
 
 ### Windows
 

--- a/lib/ae_page_objects/concerns/load_ensuring.rb
+++ b/lib/ae_page_objects/concerns/load_ensuring.rb
@@ -19,7 +19,7 @@ module AePageObjects
       
         self
       rescue Capybara::ElementNotFound => e
-        raise LoadingFailed, e.message 
+        raise LoadingElementFailed, e.message
       end
     end
   end

--- a/lib/ae_page_objects/concerns/visitable.rb
+++ b/lib/ae_page_objects/concerns/visitable.rb
@@ -10,10 +10,14 @@ module AePageObjects
     
       def ensure_loaded!
         unless Waiter.wait_for { self.class.can_load_from_current_url? }
-          raise LoadingFailed, "#{self.class.name} cannot be loaded with url '#{current_url_without_params}'"
+          raise LoadingPageFailed, "#{self.class.name} cannot be loaded with url '#{current_url_without_params}'"
         end
 
-        super
+        begin
+          super
+        rescue LoadingElementFailed
+          raise LoadingPageFailed, e.message
+        end
       end
     
       module VisitMethod

--- a/lib/ae_page_objects/element.rb
+++ b/lib/ae_page_objects/element.rb
@@ -101,6 +101,8 @@ module AePageObjects
       end
       
       parent.node
+    rescue Capybara::ElementNotFound => e
+      raise LoadingElementFailed, e.message
     end
   end
 end

--- a/lib/ae_page_objects/element_proxy.rb
+++ b/lib/ae_page_objects/element_proxy.rb
@@ -44,7 +44,7 @@ module AePageObjects
     
     def presence
       element
-    rescue Capybara::ElementNotFound
+    rescue AePageObjects::LoadingElementFailed
       nil
     end
     

--- a/lib/ae_page_objects/exceptions.rb
+++ b/lib/ae_page_objects/exceptions.rb
@@ -7,6 +7,12 @@ module AePageObjects
   class LoadingFailed < Error
   end
 
+  class LoadingPageFailed < LoadingFailed
+  end
+
+  class LoadingElementFailed < LoadingFailed
+  end
+
   class PathNotResolvable < Error
   end
 

--- a/lib/ae_page_objects/single_window/same_window_loader_strategy.rb
+++ b/lib/ae_page_objects/single_window/same_window_loader_strategy.rb
@@ -19,13 +19,13 @@ module AePageObjects
 
       def load_document(document_class)
         document_class.new
-      rescue AePageObjects::LoadingFailed
+      rescue AePageObjects::LoadingPageFailed
         nil
       end
 
       def condition_matches?(document, condition)
         condition.match?(document)
-      rescue Capybara::ElementNotFound
+      rescue AePageObjects::LoadingElementFailed
         false
       end
     end

--- a/test/test_apps/shared/test/selenium/page_object_integration_test.rb
+++ b/test/test_apps/shared/test/selenium/page_object_integration_test.rb
@@ -12,7 +12,7 @@ class PageObjectIntegrationTest < Selenium::TestCase
   def test_load_ensuring
     visit("/books/new")
     
-    exception = assert_raises AePageObjects::LoadingFailed do
+    exception = assert_raises AePageObjects::LoadingPageFailed do
       PageObjects::Authors::NewPage.new
     end
 
@@ -220,10 +220,10 @@ class PageObjectIntegrationTest < Selenium::TestCase
     assert_false author.stale?
     assert book.stale?
     
-    assert_raises AePageObjects::LoadingFailed do
+    assert_raises AePageObjects::LoadingPageFailed do
       PageObjects::Books::NewPage.new
-    end
-    
+    end 
+
     assert_false author.stale?
     assert book.stale?
   end

--- a/test/unit/element_proxy_test.rb
+++ b/test/unit/element_proxy_test.rb
@@ -38,7 +38,7 @@ module AePageObjects
     def test_presence__element_not_found
       proxy = new_proxy
       
-      element_class.expects(:new).raises(Capybara::ElementNotFound)
+      element_class.expects(:new).raises(AePageObjects::LoadingElementFailed)
       assert_nil proxy.presence
     end
     
@@ -52,7 +52,7 @@ module AePageObjects
     def test_present__element_not_found
       proxy = new_proxy
       
-      element_class.expects(:new).raises(Capybara::ElementNotFound)
+      element_class.expects(:new).raises(AePageObjects::LoadingElementFailed)
       assert_false proxy.present?
     end
 
@@ -69,7 +69,7 @@ module AePageObjects
       proxy = new_proxy
 
       with_stubbed_wait_for do
-        element_class.expects(:new).raises(Capybara::ElementNotFound)
+        element_class.expects(:new).raises(AePageObjects::LoadingElementFailed)
         assert proxy.not_present?
       end
     end
@@ -88,7 +88,7 @@ module AePageObjects
       proxy = new_proxy
 
       with_stubbed_wait_for do
-        element_class.expects(:new).raises(Capybara::ElementNotFound)
+        element_class.expects(:new).raises(AePageObjects::LoadingElementFailed)
         assert_false proxy.visible?
       end
     end
@@ -112,7 +112,7 @@ module AePageObjects
       proxy = new_proxy
 
       with_stubbed_wait_for do
-        element_class.expects(:new).raises(Capybara::ElementNotFound)
+        element_class.expects(:new).raises(AePageObjects::LoadingElementFailed)
         assert proxy.not_visible?
       end
     end

--- a/test/unit/single_window/same_window_loader_strategy_test.rb
+++ b/test/unit/single_window/same_window_loader_strategy_test.rb
@@ -30,7 +30,7 @@ module AePageObjects
       end
 
       def test_load_page_with_condition__loading_failed
-        DocumentClass.expects(:new).raises(AePageObjects::LoadingFailed.new)
+        DocumentClass.expects(:new).raises(AePageObjects::LoadingPageFailed.new)
 
         condition = DocumentQuery::Condition.new(DocumentClass)
 


### PR DESCRIPTION
Capybara::ElementNotFound is raised from Capybara#find calls.

Prior to these changes creating a new Element could fail for either Capybara::ElementNotFound or AePageObjects::LoadingFailed. 

The changes map Capybara::ElementNotFound exceptions to AePageObjects::LoadingFailed and fix a bug in ElementProxy#presence which was only handling Capybara::ElementNotFound.

Additionally, these changes make the loading failure mode across Documents and Elements consistent by having both modes raise AePageObjects::LoadingFailed subtypes for all loading failures.
