### PR TITLE
Fix build error for aepos test under rails 3.1&&ruby1.8.7

### DIFF
--- a/test/test_apps/3.1/Gemfile
+++ b/test/test_apps/3.1/Gemfile
@@ -15,6 +15,7 @@ if RUBY_VERSION =~ /\A1\.8/
   gem "nokogiri", "< 1.6.0"
   gem 'rubyzip', '< 1.0.0'
   gem 'mime-types', '< 2'
+  gem 'i18n', '~> 0.6.0'
 end
 
 gem 'forum', :path => "../engines"

--- a/test/test_apps/3.1/gemfiles/capybara_1.1_ruby1.8.7.gemfile
+++ b/test/test_apps/3.1/gemfiles/capybara_1.1_ruby1.8.7.gemfile
@@ -12,6 +12,7 @@ gem "ae_page_objects", :path=>"../../../.."
 gem "nokogiri", "< 1.6.0"
 gem "rubyzip", "< 1.0.0"
 gem "mime-types", "< 2"
+gem "i18n", "~> 0.6.0"
 gem "forum", :path=>"../engines"
 gem "capybara", "~> 1.1.4"
 


### PR DESCRIPTION
Detail:

The current version(released on December 19, 2014) of i18n(which rails depends on) REQUIRED RUBY VERSION: >= 1.9.3 (https://rubygems.org/gems/i18n)

However the Rails-3.1.12 that used in aepos integration test depends on i18n '~> 0.6'
(https://github.com/rails/rails/blob/3-1-stable/actionpack/actionpack.gemspec)
(https://github.com/rails/rails/blob/3-1-stable/activemodel/activemodel.gemspec)

As new version of i18n released, the version of i18n in rails 3.1.12 resolved to `0.7.0` but that version requires
ruby version >= 1.9.3 which make bundle install errors under 1.8.7
(https://travis-ci.org/appfolio/ae_page_objects/jobs/43120957)

Fix:
add i18n pessimistic version constraint (~> 0.6.0) under rails 3.1.12 && ruby 1.8.7
