### PR TITLE
Fix method_missing for "class" in ElementProxy

### DIFF
--- a/lib/ae_page_objects/element_proxy.rb
+++ b/lib/ae_page_objects/element_proxy.rb
@@ -121,7 +121,7 @@ module AePageObjects
     end
 
     def method_missing(name, *args, &block)
-      if name == "class"
+      if name == :class
         return @element_class
       end
 

--- a/test/unit/element_proxy_test.rb
+++ b/test/unit/element_proxy_test.rb
@@ -273,6 +273,27 @@ module AePageObjects
       assert_includes raised.message, element_class.to_s
     end
 
+    def test_class
+      proxy = new_proxy
+
+      # Faking an expectation that this method should never be called.
+      # Seems it's not possible to use 'expects' on ElementProxy which has
+      # removed all (most) methods in implements 'method_missing'
+      def proxy.implicit_element(*args)
+        address = '0x' + (object_id * 2).to_s(16)
+        inspected_object = "#<AePageObjects::ElementProxy:#{address}>"
+        message = "unexpected invocation: #{inspected_object}." \
+          "implicit_element()\n" \
+          "unsatisfied expectations:\n" \
+          "- expected never, invoked once: #{inspected_object}." \
+          'implicit_element(any_parameters)'
+
+        raise Mocha::ExpectationErrorFactory.build(message, caller)
+      end
+
+      assert_equal element_class, proxy.class
+    end
+
     private
 
     def unstub_wait_for


### PR DESCRIPTION
A fake expectation on 'implicit_element', that it should never be called, is made in the test. It seems it's not possible to use 'expects' on ElementProxy which has removed all (most) methods and implements 'method_missing'.