### PR TITLE
ll - ApplicationRouter throws exception when the path isn't resolvable

### DIFF
--- a/lib/ae_page_objects/core/application_router.rb
+++ b/lib/ae_page_objects/core/application_router.rb
@@ -45,8 +45,13 @@ module AePageObjects
         end
 
         def resolve_named_route(named_route)
-          requirements = router.named_routes[named_route].requirements
-          ResolvedRoute.new(requirements[:controller], requirements[:action])
+          found_route = router.named_routes[named_route]
+          if found_route
+            requirements = found_route.requirements
+            ResolvedRoute.new(requirements[:controller], requirements[:action])
+          else
+            raise PathNotResolvable, "#{named_route}_path does not exist in the application"
+          end
         end
 
         def resolve_url(url, method)

--- a/test/test_apps/shared/test/page_objects/books/dummy_show_page_with_unresolvable_path.rb
+++ b/test/test_apps/shared/test/page_objects/books/dummy_show_page_with_unresolvable_path.rb
@@ -1,0 +1,11 @@
+module PageObjects
+  module Books
+    class DummyShowPageWithUnresolvablePath < AePageObjects::Document
+      # This page is used to test when the first path is correct, and the second path is incorrect.
+      # In the past, the code will blow up with an unreadable error that doesn't indicate that the
+      # failure is due to the PathNotResolvable. We now tests that it has a understandable error message.
+      path :book
+      path :does_not_exist # path that does not actually exist in the app
+    end
+  end
+end

--- a/test/test_apps/shared/test/selenium/page_object_integration_test.rb
+++ b/test/test_apps/shared/test/selenium/page_object_integration_test.rb
@@ -26,6 +26,14 @@ class PageObjectIntegrationTest < Selenium::TestCase
     end
   end
 
+  def test_load_ensuring__second_path_in_page_object_is_unresolvable
+    visit("/books/new")
+
+    assert_raises AePageObjects::PathNotResolvable do
+      PageObjects::Books::DummyShowPageWithUnresolvablePath.new
+    end
+  end
+
   def test_load_ensuring__waits_for_page
     ActiveRecord::Base.transaction do
       Author.create!(:last_name => 'a')


### PR DESCRIPTION
Previously, the code raises an exception for calling a method on a nil
object when a path specified in the AePageObject::Document is not resolvable.

This is confusing to the consumer because:
1. in the stacktrace, it doesn't complain at the line the causes the problem.
2. the error message itself isn't the root cause of the problem.

To reproduce this issue, refer to the Github issue https://github.com/appfolio/ae_page_objects/issues/163