### PR TITLE
Add Node#element element factory to create elements off of existing elements

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 ### Added
 
+* [179](https://github.com/appfolio/ae_page_objects/pull/179) Add Node#element element factory to create elements off of existing elements.
 * [111](https://github.com/appfolio/ae_page_objects/issues/111) Adding wait: option to all polling query methods.
 
 ### Changed

--- a/README.md
+++ b/README.md
@@ -30,6 +30,7 @@ be used in automated acceptance test suites.
     - [Variable Results](#variable-results)
 - [Elements](#elements)
   - [Defining Elements](#defining-elements)
+  - [Creating elements on the fly](#creating-elements-on-the-fly)
   - [Nested Elements](#nested-elements)
     - [Extending Nested Elements](#extending-nested-elements)
   - [Custom Elements](#custom-elements)
@@ -526,13 +527,17 @@ default document type (the first document specified through the parameters of `w
 
 ## Elements
 
-Elements in AePageObjects represent the DOM elements on the page and are subclasses of `AePageObject::Element`. Just like
+Elements in AePageObjects represent the DOM elements on a page and are subclasses of `AePageObject::Element`. Just like
 in Capybara, all elements have a reference to their parent element. The parent of the topmost element in the element tree
 is `AePageObject::Document`.
 
 ### Defining Elements
 
-AePageObjects provides a concise DSL for expressing elements on a document. For example:
+AePageObjects provides a concise DSL for defining elements on a document. Elements defined on a document express the static
+structure of your page.
+
+For example:
+
 
 ```ruby
 class AuthorsShowPage < AePageObjects::Document
@@ -577,6 +582,18 @@ end
 ```
 
 See [Locators](#locators) for a discussion of locators.
+
+### Creating elements on the fly
+
+In addition to defining elements to express the static structure of a page, you can also create elements on the fly by
+calling the `element` method on a node:
+
+```ruby
+some_modal = some_page.element('.dialog')
+close_button = some_modal.element('.x-close')
+```
+
+`element` will return a new `AePageObjects::Element` object with a `parent` pointer to the object `element` was called on.
 
 
 ### Nested Elements

--- a/lib/ae_page_objects/core/dsl.rb
+++ b/lib/ae_page_objects/core/dsl.rb
@@ -16,18 +16,23 @@ module AePageObjects
     end
 
     def element(name, options = {}, &block)
-      options = options.dup
+      options        = options.dup
       options[:name] ||= name
+      options[:is]   ||= Element
 
-      klass   = field_klass(options, &block)
-
-      self.element_attributes[name.to_sym] = klass
-
-      define_method name do
-        ElementProxy.new(klass, self, options)
+      if block_given?
+        options[:is] = Class.new(options[:is], &block)
       end
 
-      klass
+      element_class = options[:is]
+
+      self.element_attributes[name.to_sym] = element_class
+
+      define_method name do
+        self.element(options)
+      end
+
+      element_class
     end
 
     # Defines a collection of elements. Blocks are evaluated on the item class used by the
@@ -180,18 +185,6 @@ module AePageObjects
         RUBY
 
         self.element_attributes[element_name] = element_klazz
-      end
-    end
-
-  private
-
-    def field_klass(options, &block)
-      klass = options.delete(:is) || Element
-
-      if block_given?
-        Class.new(klass, &block)
-      else
-        klass
       end
     end
   end

--- a/lib/ae_page_objects/elements/collection.rb
+++ b/lib/ae_page_objects/elements/collection.rb
@@ -57,7 +57,7 @@ module AePageObjects
     end
 
     def item_at(index)
-      ElementProxy.new(item_class_at(index), self, :name => index, :locator => item_locator_at(index))
+      element(is: item_class_at(index), name: index, locator: item_locator_at(index))
     end
 
     def item_class_at(index)

--- a/lib/ae_page_objects/node.rb
+++ b/lib/ae_page_objects/node.rb
@@ -60,6 +60,18 @@ module AePageObjects
       RUBY
     end
 
+    def element(options_or_locator)
+      options = if options_or_locator.is_a?(Hash)
+                  options_or_locator.dup
+                else
+                  {:locator => options_or_locator}
+                end
+
+      element_class = options.delete(:is) || Element
+
+      ElementProxy.new(element_class, self, options)
+    end
+
     private
 
     def eval_locator(locator)

--- a/test/test_helpers/element_test_helpers.rb
+++ b/test/test_helpers/element_test_helpers.rb
@@ -1,4 +1,4 @@
-module NodeFieldTestHelpers
+module ElementTestHelpers
 
   def assert_nodes_equal(expected, value)
     assert_equal expected.class, value.class

--- a/test/test_helpers/node_field_test_helpers.rb
+++ b/test/test_helpers/node_field_test_helpers.rb
@@ -11,15 +11,19 @@ module NodeFieldTestHelpers
     assert_equal expected.__name__, value.__name__
   end
 
+  def verify_element(element, expected_element_type, expected_parent, expected_capybara_node)
+    assert element.is_a?(expected_element_type)
+    assert element.is_a?(AePageObjects::ElementProxy)
+    assert_equal expected_element_type, element.class
+    assert_equal expected_capybara_node, element.node
+    assert_equal expected_parent, element.parent
+  end
+
   def verify_field(parent, field_method, expected_field_type, expected_field_page)
     assert_equal expected_field_type, parent.class.element_attributes[field_method]
 
     parent.send(field_method).tap do |field|
-      assert field.is_a?(expected_field_type)
-      assert field.is_a?(AePageObjects::ElementProxy)
-      assert_equal expected_field_type, field.class
-      assert_equal expected_field_page, field.node
-      assert_equal parent, field.parent
+      verify_element(field, expected_field_type, parent, expected_field_page)
     end
   end
 

--- a/test/test_helpers/node_field_test_helpers.rb
+++ b/test/test_helpers/node_field_test_helpers.rb
@@ -19,7 +19,7 @@ module NodeFieldTestHelpers
     assert_equal expected_parent, element.parent
   end
 
-  def verify_field(parent, field_method, expected_field_type, expected_field_page)
+  def verify_element_on_parent(parent, field_method, expected_field_type, expected_field_page)
     assert_equal expected_field_type, parent.class.element_attributes[field_method]
 
     parent.send(field_method).tap do |field|
@@ -27,7 +27,7 @@ module NodeFieldTestHelpers
     end
   end
 
-  def verify_field_with_intermediary_class(parent, field_method, expected_field_type, expected_field_page)
+  def verify_element_on_parent_with_intermediary_class(parent, field_method, expected_field_type, expected_field_page)
     assert_equal expected_field_type, parent.class.element_attributes[field_method].superclass
 
     parent.send(field_method).tap do |field|
@@ -35,26 +35,6 @@ module NodeFieldTestHelpers
       assert_equal expected_field_type, field.class.superclass
       assert_equal expected_field_page, field.node
       assert_equal parent, field.parent
-    end
-  end
-
-  def verify_item_field(collection, index, expected_item_type, expected_item_page)
-    collection[index].tap do |item|
-      assert       item.is_a?(AePageObjects::ElementProxy)
-      assert_equal expected_item_type, item.class
-      assert_equal collection.item_class, item.class
-      assert_equal expected_item_page, item.node
-      assert_equal collection, item.parent
-    end
-  end
-
-  def verify_item_field_with_intermediary_class(collection, index, expected_item_type, expected_item_page)
-    collection[index].tap do |item|
-      assert       item.is_a?(AePageObjects::ElementProxy)
-      assert_equal expected_item_type, item.class.superclass
-      assert_equal collection.item_class, item.class
-      assert_equal expected_item_page, item.node
-      assert_equal collection, item.parent
     end
   end
 end

--- a/test/test_helpers/node_interface_tests.rb
+++ b/test/test_helpers/node_interface_tests.rb
@@ -1,4 +1,6 @@
 module NodeInterfaceTests
+  include NodeFieldTestHelpers
+
   def test_node_method_wraps_not_found
     subject = node_for_node_tests
 
@@ -14,7 +16,39 @@ module NodeInterfaceTests
     end
   end
 
-private
+  def test_element_factory__basic
+    subject = node_for_node_tests
+
+    element = subject.element("#blahblah")
+
+    capybara_node = mock
+    capybara_stub.session.expects(:find).with("#blahblah").returns(capybara_node)
+    verify_element(element, AePageObjects::Element, subject, capybara_node)
+  end
+
+  def test_element_factory__locator
+    subject = node_for_node_tests
+
+    element = subject.element(:locator => ["#blahblah", {:visible => true}])
+
+    capybara_node = mock
+    capybara_stub.session.expects(:find).with("#blahblah", :visible => true).returns(capybara_node)
+    verify_element(element, AePageObjects::Element, subject, capybara_node)
+  end
+
+  def test_element_factory__element_class
+    element_class = Class.new(AePageObjects::Element)
+
+    subject = node_for_node_tests
+
+    element = subject.element(:locator => ["#blahblah", {:visible => true}], :is => element_class)
+
+    capybara_node = mock
+    capybara_stub.session.expects(:find).with("#blahblah", :visible => true).returns(capybara_node)
+    verify_element(element, element_class, subject, capybara_node)
+  end
+
+  private
 
   def node_for_node_tests
     raise "Must implement!"

--- a/test/test_helpers/node_interface_tests.rb
+++ b/test/test_helpers/node_interface_tests.rb
@@ -1,5 +1,7 @@
+require 'test_helpers/element_test_helpers'
+
 module NodeInterfaceTests
-  include NodeFieldTestHelpers
+  include ElementTestHelpers
 
   def test_node_method_wraps_not_found
     subject = node_for_node_tests

--- a/test/unit/document_test.rb
+++ b/test/unit/document_test.rb
@@ -1,5 +1,7 @@
 require 'unit_helper'
 
+require 'test_helpers/node_interface_tests'
+
 module AePageObjects
   class DocumentTest < AePageObjectsTestCase
     include NodeInterfaceTests

--- a/test/unit/dsl/collection_test.rb
+++ b/test/unit/dsl/collection_test.rb
@@ -21,20 +21,20 @@ module AePageObjects
         previous_owners_page_object = mock
         capybara_stub.session.expects(:find).with("#previous_owners").returns(previous_owners_page_object)
 
-        previous_owners = verify_field_with_intermediary_class(jon, :previous_owners, AePageObjects::Collection, previous_owners_page_object)
+        previous_owners = verify_element_on_parent_with_intermediary_class(jon, :previous_owners, AePageObjects::Collection, previous_owners_page_object)
 
         first_owner_page_object = mock
         previous_owners_page_object.expects(:all).with(:xpath,  ".//*").returns([first_owner_page_object])
         previous_owners_page_object.expects(:find).with(:xpath, ".//*[1]").returns(first_owner_page_object)
-        first_owner = verify_item_field_with_intermediary_class(previous_owners, 0, AePageObjects::Element, first_owner_page_object)
+        first_owner = verify_item_element_with_intermediary_class(previous_owners, 0, AePageObjects::Element, first_owner_page_object)
 
         owner_name_page_object = mock
         first_owner_page_object.expects(:find).with("#previous_owners_0_owner_name").returns(owner_name_page_object)
-        verify_field(first_owner, :owner_name, AePageObjects::Element, owner_name_page_object)
+        verify_element_on_parent(first_owner, :owner_name, AePageObjects::Element, owner_name_page_object)
 
         kitty_name_during_ownership_page_object = mock
         first_owner_page_object.expects(:find).with("#previous_owners_0_kitty_name_during_ownership").returns(kitty_name_during_ownership_page_object)
-        verify_field(first_owner, :kitty_name_during_ownership, AePageObjects::Element, kitty_name_during_ownership_page_object)
+        verify_element_on_parent(first_owner, :kitty_name_during_ownership, AePageObjects::Element, kitty_name_during_ownership_page_object)
       end
 
       def test_collection__is__no_contains__block
@@ -57,21 +57,21 @@ module AePageObjects
         previous_owners_page_object = mock
         capybara_stub.session.expects(:find).with("#previous_owners").returns(previous_owners_page_object)
 
-        previous_owners = verify_field_with_intermediary_class(jon, :previous_owners, previous_owners_class, previous_owners_page_object)
+        previous_owners = verify_element_on_parent_with_intermediary_class(jon, :previous_owners, previous_owners_class, previous_owners_page_object)
 
         first_owner_page_object = mock
 
         previous_owners_page_object.expects(:all).with(:xpath, ".//*").returns([first_owner_page_object])
         previous_owners_page_object.expects(:find).with(:xpath, ".//*[1]").returns(first_owner_page_object)
-        first_owner = verify_item_field_with_intermediary_class(previous_owners, 0, previous_owners_class.item_class, first_owner_page_object)
+        first_owner = verify_item_element_with_intermediary_class(previous_owners, 0, previous_owners_class.item_class, first_owner_page_object)
 
         owner_name_page_object = mock
         first_owner_page_object.expects(:find).with("#previous_owners_0_owner_name").returns(owner_name_page_object)
-        verify_field(first_owner, :owner_name, AePageObjects::Element, owner_name_page_object)
+        verify_element_on_parent(first_owner, :owner_name, AePageObjects::Element, owner_name_page_object)
 
         kitty_name_during_ownership_page_object = mock
         first_owner_page_object.expects(:find).with("#previous_owners_0_kitty_name_during_ownership").returns(kitty_name_during_ownership_page_object)
-        verify_field(first_owner, :kitty_name_during_ownership, AePageObjects::Element, kitty_name_during_ownership_page_object)
+        verify_element_on_parent(first_owner, :kitty_name_during_ownership, AePageObjects::Element, kitty_name_during_ownership_page_object)
       end
 
       def test_collection__is__no_contains__block__no_item_class
@@ -93,21 +93,21 @@ module AePageObjects
         previous_owners_page_object = mock
         capybara_stub.session.expects(:find).with("#previous_owners").returns(previous_owners_page_object)
 
-        previous_owners = verify_field_with_intermediary_class(jon, :previous_owners, previous_owners_class, previous_owners_page_object)
+        previous_owners = verify_element_on_parent_with_intermediary_class(jon, :previous_owners, previous_owners_class, previous_owners_page_object)
 
         first_owner_page_object = mock
 
         previous_owners_page_object.expects(:all).with(:xpath, ".//*").returns([first_owner_page_object])
         previous_owners_page_object.expects(:find).with(:xpath, ".//*[1]").returns(first_owner_page_object)
-        first_owner = verify_item_field_with_intermediary_class(previous_owners, 0, previous_owners_class.item_class, first_owner_page_object)
+        first_owner = verify_item_element_with_intermediary_class(previous_owners, 0, previous_owners_class.item_class, first_owner_page_object)
 
         owner_name_page_object = mock
         first_owner_page_object.expects(:find).with("#previous_owners_0_owner_name").returns(owner_name_page_object)
-        verify_field(first_owner, :owner_name, AePageObjects::Element, owner_name_page_object)
+        verify_element_on_parent(first_owner, :owner_name, AePageObjects::Element, owner_name_page_object)
 
         kitty_name_during_ownership_page_object = mock
         first_owner_page_object.expects(:find).with("#previous_owners_0_kitty_name_during_ownership").returns(kitty_name_during_ownership_page_object)
-        verify_field(first_owner, :kitty_name_during_ownership, AePageObjects::Element, kitty_name_during_ownership_page_object)
+        verify_element_on_parent(first_owner, :kitty_name_during_ownership, AePageObjects::Element, kitty_name_during_ownership_page_object)
       end
 
       def test_collection__is__no_contains__no_block
@@ -132,20 +132,20 @@ module AePageObjects
         previous_owners_page_object = mock
         capybara_stub.session.expects(:find).with("#previous_owners").returns(previous_owners_page_object)
 
-        previous_owners = verify_field(jon, :previous_owners, previous_owners_class, previous_owners_page_object)
+        previous_owners = verify_element_on_parent(jon, :previous_owners, previous_owners_class, previous_owners_page_object)
 
         first_owner_page_object = mock
         previous_owners_page_object.expects(:all).with(:xpath,  ".//*").returns([first_owner_page_object])
         previous_owners_page_object.expects(:find).with(:xpath, ".//*[1]").returns(first_owner_page_object)
-        first_owner = verify_item_field(previous_owners, 0, previous_owner_class, first_owner_page_object)
+        first_owner = verify_item_element(previous_owners, 0, previous_owner_class, first_owner_page_object)
 
         owner_name_page_object = mock
         first_owner_page_object.expects(:find).with("#previous_owners_0_owner_name").returns(owner_name_page_object)
-        verify_field(first_owner, :owner_name, AePageObjects::Element, owner_name_page_object)
+        verify_element_on_parent(first_owner, :owner_name, AePageObjects::Element, owner_name_page_object)
 
         kitty_name_during_ownership_page_object = mock
         first_owner_page_object.expects(:find).with("#previous_owners_0_kitty_name_during_ownership").returns(kitty_name_during_ownership_page_object)
-        verify_field(first_owner, :kitty_name_during_ownership, AePageObjects::Element, kitty_name_during_ownership_page_object)
+        verify_element_on_parent(first_owner, :kitty_name_during_ownership, AePageObjects::Element, kitty_name_during_ownership_page_object)
       end
 
       def test_collection__is__contains__no_block__same_item_class
@@ -170,20 +170,20 @@ module AePageObjects
         previous_owners_page_object = mock
         capybara_stub.session.expects(:find).with("#previous_owners").returns(previous_owners_page_object)
 
-        previous_owners = verify_field(jon, :previous_owners, previous_owners_class, previous_owners_page_object)
+        previous_owners = verify_element_on_parent(jon, :previous_owners, previous_owners_class, previous_owners_page_object)
 
         first_owner_page_object = mock
         previous_owners_page_object.expects(:all).with(:xpath,  ".//*").returns([first_owner_page_object])
         previous_owners_page_object.expects(:find).with(:xpath, ".//*[1]").returns(first_owner_page_object)
-        first_owner = verify_item_field(previous_owners, 0, previous_owner_class, first_owner_page_object)
+        first_owner = verify_item_element(previous_owners, 0, previous_owner_class, first_owner_page_object)
 
         owner_name_page_object = mock
         first_owner_page_object.expects(:find).with("#previous_owners_0_owner_name").returns(owner_name_page_object)
-        verify_field(first_owner, :owner_name, AePageObjects::Element, owner_name_page_object)
+        verify_element_on_parent(first_owner, :owner_name, AePageObjects::Element, owner_name_page_object)
 
         kitty_name_during_ownership_page_object = mock
         first_owner_page_object.expects(:find).with("#previous_owners_0_kitty_name_during_ownership").returns(kitty_name_during_ownership_page_object)
-        verify_field(first_owner, :kitty_name_during_ownership, AePageObjects::Element, kitty_name_during_ownership_page_object)
+        verify_element_on_parent(first_owner, :kitty_name_during_ownership, AePageObjects::Element, kitty_name_during_ownership_page_object)
       end
 
       def test_collection__is__contains__no_block__different_item_class
@@ -206,20 +206,20 @@ module AePageObjects
         previous_owners_page_object = mock
         capybara_stub.session.expects(:find).with("#previous_owners").returns(previous_owners_page_object)
 
-        previous_owners = verify_field_with_intermediary_class(jon, :previous_owners, previous_owners_class, previous_owners_page_object)
+        previous_owners = verify_element_on_parent_with_intermediary_class(jon, :previous_owners, previous_owners_class, previous_owners_page_object)
 
         first_owner_page_object = mock
         previous_owners_page_object.expects(:all).with(:xpath,  ".//*").returns([first_owner_page_object])
         previous_owners_page_object.expects(:find).with(:xpath, ".//*[1]").returns(first_owner_page_object)
-        first_owner = verify_item_field(previous_owners, 0, previous_owner_class, first_owner_page_object)
+        first_owner = verify_item_element(previous_owners, 0, previous_owner_class, first_owner_page_object)
 
         owner_name_page_object = mock
         first_owner_page_object.expects(:find).with("#previous_owners_0_owner_name").returns(owner_name_page_object)
-        verify_field(first_owner, :owner_name, AePageObjects::Element, owner_name_page_object)
+        verify_element_on_parent(first_owner, :owner_name, AePageObjects::Element, owner_name_page_object)
 
         kitty_name_during_ownership_page_object = mock
         first_owner_page_object.expects(:find).with("#previous_owners_0_kitty_name_during_ownership").returns(kitty_name_during_ownership_page_object)
-        verify_field(first_owner, :kitty_name_during_ownership, AePageObjects::Element, kitty_name_during_ownership_page_object)
+        verify_element_on_parent(first_owner, :kitty_name_during_ownership, AePageObjects::Element, kitty_name_during_ownership_page_object)
       end
 
       def test_collection__no_is__contains__no_block
@@ -240,20 +240,20 @@ module AePageObjects
         previous_owners_page_object = mock
         capybara_stub.session.expects(:find).with("#previous_owners").returns(previous_owners_page_object)
 
-        previous_owners = verify_field_with_intermediary_class(jon, :previous_owners, AePageObjects::Collection, previous_owners_page_object)
+        previous_owners = verify_element_on_parent_with_intermediary_class(jon, :previous_owners, AePageObjects::Collection, previous_owners_page_object)
 
         first_owner_page_object = mock
         previous_owners_page_object.expects(:all).with(:xpath,  ".//*").returns([first_owner_page_object])
         previous_owners_page_object.expects(:find).with(:xpath, ".//*[1]").returns(first_owner_page_object)
-        first_owner = verify_item_field(previous_owners, 0, previous_owner_class, first_owner_page_object)
+        first_owner = verify_item_element(previous_owners, 0, previous_owner_class, first_owner_page_object)
 
         owner_name_page_object = mock
         first_owner_page_object.expects(:find).with("#previous_owners_0_owner_name").returns(owner_name_page_object)
-        verify_field(first_owner, :owner_name, AePageObjects::Element, owner_name_page_object)
+        verify_element_on_parent(first_owner, :owner_name, AePageObjects::Element, owner_name_page_object)
 
         kitty_name_during_ownership_page_object = mock
         first_owner_page_object.expects(:find).with("#previous_owners_0_kitty_name_during_ownership").returns(kitty_name_during_ownership_page_object)
-        verify_field(first_owner, :kitty_name_during_ownership, AePageObjects::Element, kitty_name_during_ownership_page_object)
+        verify_element_on_parent(first_owner, :kitty_name_during_ownership, AePageObjects::Element, kitty_name_during_ownership_page_object)
       end
 
       def test_collection__no_is__contains__block
@@ -276,20 +276,20 @@ module AePageObjects
         previous_owners_page_object = mock
         capybara_stub.session.expects(:find).with("#previous_owners").returns(previous_owners_page_object)
 
-        previous_owners = verify_field_with_intermediary_class(jon, :previous_owners, AePageObjects::Collection, previous_owners_page_object)
+        previous_owners = verify_element_on_parent_with_intermediary_class(jon, :previous_owners, AePageObjects::Collection, previous_owners_page_object)
 
         first_owner_page_object = mock
         previous_owners_page_object.expects(:all).with(:xpath,  ".//*").returns([first_owner_page_object])
         previous_owners_page_object.expects(:find).with(:xpath, ".//*[1]").returns(first_owner_page_object)
-        first_owner = verify_item_field_with_intermediary_class(previous_owners, 0, previous_owner_class, first_owner_page_object)
+        first_owner = verify_item_element_with_intermediary_class(previous_owners, 0, previous_owner_class, first_owner_page_object)
 
         owner_name_page_object = mock
         first_owner_page_object.expects(:find).with("#previous_owners_0_owner_name").returns(owner_name_page_object)
-        verify_field(first_owner, :owner_name, AePageObjects::Element, owner_name_page_object)
+        verify_element_on_parent(first_owner, :owner_name, AePageObjects::Element, owner_name_page_object)
 
         kitty_name_during_ownership_page_object = mock
         first_owner_page_object.expects(:find).with("#previous_owners_0_kitty_name_during_ownership").returns(kitty_name_during_ownership_page_object)
-        verify_field(first_owner, :kitty_name_during_ownership, AePageObjects::Element, kitty_name_during_ownership_page_object)
+        verify_element_on_parent(first_owner, :kitty_name_during_ownership, AePageObjects::Element, kitty_name_during_ownership_page_object)
       end
 
       def test_collection__is__contains__block
@@ -319,20 +319,20 @@ module AePageObjects
         previous_owners_page_object = mock
         capybara_stub.session.expects(:find).with("#previous_owners").returns(previous_owners_page_object)
 
-        previous_owners = verify_field_with_intermediary_class(jon, :previous_owners, previous_owners_class, previous_owners_page_object)
+        previous_owners = verify_element_on_parent_with_intermediary_class(jon, :previous_owners, previous_owners_class, previous_owners_page_object)
 
         first_owner_page_object = mock
         previous_owners_page_object.expects(:all).with(:xpath,  ".//*").returns([first_owner_page_object])
         previous_owners_page_object.expects(:find).with(:xpath, ".//*[1]").returns(first_owner_page_object)
-        first_owner = verify_item_field_with_intermediary_class(previous_owners, 0, previous_owner_class, first_owner_page_object)
+        first_owner = verify_item_element_with_intermediary_class(previous_owners, 0, previous_owner_class, first_owner_page_object)
 
         owner_name_page_object = mock
         first_owner_page_object.expects(:find).with("#previous_owners_0_owner_name").returns(owner_name_page_object)
-        verify_field(first_owner, :owner_name, AePageObjects::Element, owner_name_page_object)
+        verify_element_on_parent(first_owner, :owner_name, AePageObjects::Element, owner_name_page_object)
 
         kitty_name_during_ownership_page_object = mock
         first_owner_page_object.expects(:find).with("#previous_owners_0_kitty_name_during_ownership").returns(kitty_name_during_ownership_page_object)
-        verify_field(first_owner, :kitty_name_during_ownership, AePageObjects::Element, kitty_name_during_ownership_page_object)
+        verify_element_on_parent(first_owner, :kitty_name_during_ownership, AePageObjects::Element, kitty_name_during_ownership_page_object)
       end
 
       def test_collection__no_is__no_contains__no_block
@@ -347,12 +347,12 @@ module AePageObjects
         previous_owners_page_object = mock
         capybara_stub.session.expects(:find).with("#previous_owners").returns(previous_owners_page_object)
 
-        previous_owners = verify_field_with_intermediary_class(jon, :previous_owners, AePageObjects::Collection, previous_owners_page_object)
+        previous_owners = verify_element_on_parent_with_intermediary_class(jon, :previous_owners, AePageObjects::Collection, previous_owners_page_object)
 
         first_owner_page_object = mock
         previous_owners_page_object.expects(:all).with(:xpath,  ".//*").returns([first_owner_page_object])
         previous_owners_page_object.expects(:find).with(:xpath, ".//*[1]").returns(first_owner_page_object)
-        first_owner = verify_item_field(previous_owners, 0, AePageObjects::Element, first_owner_page_object)
+        first_owner = verify_item_element(previous_owners, 0, AePageObjects::Element, first_owner_page_object)
       end
 
       def test_collection__locator
@@ -372,20 +372,20 @@ module AePageObjects
         previous_owners_page_object = mock
         capybara_stub.session.expects(:find).with("whatever you want, baby").returns(previous_owners_page_object)
 
-        previous_owners = verify_field_with_intermediary_class(jon, :previous_owners, AePageObjects::Collection, previous_owners_page_object)
+        previous_owners = verify_element_on_parent_with_intermediary_class(jon, :previous_owners, AePageObjects::Collection, previous_owners_page_object)
 
         first_owner_page_object = mock
         previous_owners_page_object.expects(:all).with(:xpath,  ".//*").returns([first_owner_page_object])
         previous_owners_page_object.expects(:find).with(:xpath, ".//*[1]").returns(first_owner_page_object)
-        first_owner = verify_item_field_with_intermediary_class(previous_owners, 0, AePageObjects::Element, first_owner_page_object)
+        first_owner = verify_item_element_with_intermediary_class(previous_owners, 0, AePageObjects::Element, first_owner_page_object)
 
         owner_name_page_object = mock
         first_owner_page_object.expects(:find).with("#previous_owners_0_owner_name").returns(owner_name_page_object)
-        verify_field(first_owner, :owner_name, AePageObjects::Element, owner_name_page_object)
+        verify_element_on_parent(first_owner, :owner_name, AePageObjects::Element, owner_name_page_object)
 
         kitty_name_during_ownership_page_object = mock
         first_owner_page_object.expects(:find).with("Kitty Name").returns(kitty_name_during_ownership_page_object)
-        verify_field(first_owner, :kitty_name_during_ownership, AePageObjects::Element, kitty_name_during_ownership_page_object)
+        verify_element_on_parent(first_owner, :kitty_name_during_ownership, AePageObjects::Element, kitty_name_during_ownership_page_object)
       end
 
       def test_nested_element__locator__proc
@@ -407,23 +407,23 @@ module AePageObjects
         previous_owners_page_object = mock
         capybara_stub.session.expects(:find).with("hello").returns(previous_owners_page_object)
 
-        previous_owners = verify_field_with_intermediary_class(jon, :previous_owners, AePageObjects::Collection, previous_owners_page_object)
+        previous_owners = verify_element_on_parent_with_intermediary_class(jon, :previous_owners, AePageObjects::Collection, previous_owners_page_object)
 
         first_owner_page_object = mock
         previous_owners_page_object.expects(:all).with(:xpath,  ".//*").returns([first_owner_page_object])
         previous_owners_page_object.expects(:find).with(:xpath, ".//*[1]").returns(first_owner_page_object)
-        first_owner = verify_item_field_with_intermediary_class(previous_owners, 0, AePageObjects::Element, first_owner_page_object)
+        first_owner = verify_item_element_with_intermediary_class(previous_owners, 0, AePageObjects::Element, first_owner_page_object)
 
         owner_name_page_object = mock
         first_owner_page_object.expects(:find).with("#previous_owners_0_owner_name").returns(owner_name_page_object)
-        verify_field(first_owner, :owner_name, AePageObjects::Element, owner_name_page_object)
+        verify_element_on_parent(first_owner, :owner_name, AePageObjects::Element, owner_name_page_object)
 
         kitty_name_during_ownership_page_object = mock
         first_owner_page_object.expects(:find).with("Milkshake").returns(kitty_name_during_ownership_page_object)
 
         first_owner.expects(:page_local_context).returns("Milkshake")
 
-        verify_field(first_owner, :kitty_name_during_ownership, AePageObjects::Element, kitty_name_during_ownership_page_object)
+        verify_element_on_parent(first_owner, :kitty_name_during_ownership, AePageObjects::Element, kitty_name_during_ownership_page_object)
       end
 
     private
@@ -431,6 +431,26 @@ module AePageObjects
       def verify_kitty_structure(kitty_class)
         assert_equal [:previous_owners], kitty_class.element_attributes.keys
         assert_equal [:kitty_name_during_ownership, :owner_name], kitty_class.element_attributes[:previous_owners].item_class.element_attributes.keys.sort
+      end
+
+      def verify_item_element(collection, index, expected_item_type, expected_item_page)
+        collection[index].tap do |item|
+          assert       item.is_a?(AePageObjects::ElementProxy)
+          assert_equal expected_item_type, item.class
+          assert_equal collection.item_class, item.class
+          assert_equal expected_item_page, item.node
+          assert_equal collection, item.parent
+        end
+      end
+
+      def verify_item_element_with_intermediary_class(collection, index, expected_item_type, expected_item_page)
+        collection[index].tap do |item|
+          assert       item.is_a?(AePageObjects::ElementProxy)
+          assert_equal expected_item_type, item.class.superclass
+          assert_equal collection.item_class, item.class
+          assert_equal expected_item_page, item.node
+          assert_equal collection, item.parent
+        end
       end
     end
   end

--- a/test/unit/dsl/element_test.rb
+++ b/test/unit/dsl/element_test.rb
@@ -16,7 +16,7 @@ module AePageObjects
 
         kind_page_object = mock
         capybara_stub.session.expects(:find).with("#kind").returns(kind_page_object)
-        verify_field(jon, :kind, AePageObjects::Element, kind_page_object)
+        verify_element_on_parent(jon, :kind, AePageObjects::Element, kind_page_object)
       end
 
       def test_element__locator
@@ -33,7 +33,7 @@ module AePageObjects
 
         kind_page_object = mock
         capybara_stub.session.expects(:find).with("Kind Homie").returns(kind_page_object)
-        verify_field(jon, :kind, AePageObjects::Element, kind_page_object)
+        verify_element_on_parent(jon, :kind, AePageObjects::Element, kind_page_object)
       end
 
       def test_element__locator__proc
@@ -51,7 +51,7 @@ module AePageObjects
 
         kind_page_object = mock
         capybara_stub.session.expects(:find).with("hello").returns(kind_page_object)
-        verify_field(jon, :kind, AePageObjects::Element, kind_page_object)
+        verify_element_on_parent(jon, :kind, AePageObjects::Element, kind_page_object)
       end
 
       def test_element__is__select
@@ -68,7 +68,7 @@ module AePageObjects
 
         kind_page_object = mock
         capybara_stub.session.expects(:find).with("#kind").returns(kind_page_object)
-        verify_field(jon, :kind, AePageObjects::Select, kind_page_object)
+        verify_element_on_parent(jon, :kind, AePageObjects::Select, kind_page_object)
       end
 
       def test_element__is__checkbox
@@ -85,7 +85,7 @@ module AePageObjects
 
         kind_page_object = mock
         capybara_stub.session.expects(:find).with("#kind").returns(kind_page_object)
-        verify_field(jon, :kind, AePageObjects::Checkbox, kind_page_object)
+        verify_element_on_parent(jon, :kind, AePageObjects::Checkbox, kind_page_object)
       end
 
       def test_element__is__special_widget
@@ -105,7 +105,7 @@ module AePageObjects
         kind_page_object = mock
         capybara_stub.session.expects(:find).with("#kind").returns(kind_page_object)
 
-        verify_field(jon, :kind, special_widget, kind_page_object)
+        verify_element_on_parent(jon, :kind, special_widget, kind_page_object)
       end
 
       def test_element__is__special_widget__with_locator
@@ -125,7 +125,7 @@ module AePageObjects
         kind_page_object = mock
         capybara_stub.session.expects(:find).with("As If!").returns(kind_page_object)
 
-        verify_field(jon, :kind, special_widget, kind_page_object)
+        verify_element_on_parent(jon, :kind, special_widget, kind_page_object)
       end
 
       def test_nested_element__block
@@ -152,25 +152,25 @@ module AePageObjects
         tail_page_object = mock
         capybara_stub.session.expects(:find).with("#tail_attributes").returns(tail_page_object)
 
-        tail = verify_field_with_intermediary_class(jon, :tail, AePageObjects::Element, tail_page_object)
+        tail = verify_element_on_parent_with_intermediary_class(jon, :tail, AePageObjects::Element, tail_page_object)
 
         color_page_object = mock
         tail_page_object.expects(:find).with("#tail_attributes_color").returns(color_page_object)
-        verify_field(tail, :color, AePageObjects::Element, color_page_object)
+        verify_element_on_parent(tail, :color, AePageObjects::Element, color_page_object)
 
         size_page_object = mock
         tail_page_object.expects(:find).with("#tail_attributes_size_attributes").returns(size_page_object)
-        size = verify_field_with_intermediary_class(tail, :size, AePageObjects::Element, size_page_object)
+        size = verify_element_on_parent_with_intermediary_class(tail, :size, AePageObjects::Element, size_page_object)
 
         assert_equal "Growing!", size.grow!
 
         length_page_object = mock
         size_page_object.expects(:find).with("#tail_attributes_size_attributes_length").returns(length_page_object)
-        verify_field(size, :length, AePageObjects::Element, length_page_object)
+        verify_element_on_parent(size, :length, AePageObjects::Element, length_page_object)
 
         width_page_object = mock
         size_page_object.expects(:find).with("#tail_attributes_size_attributes_width").returns(width_page_object)
-        verify_field(size, :width, AePageObjects::Element, width_page_object)
+        verify_element_on_parent(size, :width, AePageObjects::Element, width_page_object)
       end
 
       def test_nested_element__is
@@ -199,25 +199,25 @@ module AePageObjects
         tail_page_object = mock
         capybara_stub.session.expects(:find).with("#tail_attributes").returns(tail_page_object)
 
-        tail = verify_field(jon, :tail, tail_class, tail_page_object)
+        tail = verify_element_on_parent(jon, :tail, tail_class, tail_page_object)
 
         color_page_object = mock
         tail_page_object.expects(:find).with("#tail_attributes_color").returns(color_page_object)
-        verify_field(tail, :color, AePageObjects::Element, color_page_object)
+        verify_element_on_parent(tail, :color, AePageObjects::Element, color_page_object)
 
         size_page_object = mock
         tail_page_object.expects(:find).with("#tail_attributes_size_attributes").returns(size_page_object)
-        size = verify_field_with_intermediary_class(tail, :size, AePageObjects::Element, size_page_object)
+        size = verify_element_on_parent_with_intermediary_class(tail, :size, AePageObjects::Element, size_page_object)
 
         assert_equal "Growing!", size.grow!
 
         length_page_object = mock
         size_page_object.expects(:find).with("#tail_attributes_size_attributes_length").returns(length_page_object)
-        verify_field(size, :length, AePageObjects::Element, length_page_object)
+        verify_element_on_parent(size, :length, AePageObjects::Element, length_page_object)
 
         width_page_object = mock
         size_page_object.expects(:find).with("#tail_attributes_size_attributes_width", anything).returns(width_page_object)
-        verify_field(size, :width, AePageObjects::Element, width_page_object)
+        verify_element_on_parent(size, :width, AePageObjects::Element, width_page_object)
       end
 
       def test_nested_element__is__block
@@ -246,25 +246,25 @@ module AePageObjects
         tail_page_object = mock
         capybara_stub.session.expects(:find).with("#tail_attributes").returns(tail_page_object)
 
-        tail = verify_field_with_intermediary_class(jon, :tail, tail_base_class, tail_page_object)
+        tail = verify_element_on_parent_with_intermediary_class(jon, :tail, tail_base_class, tail_page_object)
 
         color_page_object = mock
         tail_page_object.expects(:find).with("#tail_attributes_color").returns(color_page_object)
-        verify_field(tail, :color, AePageObjects::Element, color_page_object)
+        verify_element_on_parent(tail, :color, AePageObjects::Element, color_page_object)
 
         size_page_object = mock
         tail_page_object.expects(:find).with("#tail_attributes_size_attributes").returns(size_page_object)
-        size = verify_field_with_intermediary_class(tail, :size, AePageObjects::Element, size_page_object)
+        size = verify_element_on_parent_with_intermediary_class(tail, :size, AePageObjects::Element, size_page_object)
 
         assert_equal "Growing!", size.grow!
 
         length_page_object = mock
         size_page_object.expects(:find).with("#tail_attributes_size_attributes_length").returns(length_page_object)
-        verify_field(size, :length, AePageObjects::Element, length_page_object)
+        verify_element_on_parent(size, :length, AePageObjects::Element, length_page_object)
 
         width_page_object = mock
         size_page_object.expects(:find).with("#tail_attributes_size_attributes_width").returns(width_page_object)
-        verify_field(size, :width, AePageObjects::Element, width_page_object)
+        verify_element_on_parent(size, :width, AePageObjects::Element, width_page_object)
       end
 
       def test_nested_element__locator
@@ -291,25 +291,25 @@ module AePageObjects
         tail_page_object = mock
         capybara_stub.session.expects(:find).with("what ever you want, baby").returns(tail_page_object)
 
-        tail = verify_field_with_intermediary_class(jon, :tail, AePageObjects::Element, tail_page_object)
+        tail = verify_element_on_parent_with_intermediary_class(jon, :tail, AePageObjects::Element, tail_page_object)
 
         color_page_object = mock
         tail_page_object.expects(:find).with("#tail_attributes_color").returns(color_page_object)
-        verify_field(tail, :color, AePageObjects::Element, color_page_object)
+        verify_element_on_parent(tail, :color, AePageObjects::Element, color_page_object)
 
         size_page_object = mock
         tail_page_object.expects(:find).with("Size").returns(size_page_object)
-        size = verify_field_with_intermediary_class(tail, :size, AePageObjects::Element, size_page_object)
+        size = verify_element_on_parent_with_intermediary_class(tail, :size, AePageObjects::Element, size_page_object)
 
         assert_equal "Growing!", size.grow!
 
         length_page_object = mock
         size_page_object.expects(:find).with("#tail_attributes_size_attributes_length").returns(length_page_object)
-        verify_field(size, :length, AePageObjects::Element, length_page_object)
+        verify_element_on_parent(size, :length, AePageObjects::Element, length_page_object)
 
         width_page_object = mock
         size_page_object.expects(:find).with("Fatness").returns(width_page_object)
-        verify_field(size, :width, AePageObjects::Element, width_page_object)
+        verify_element_on_parent(size, :width, AePageObjects::Element, width_page_object)
       end
 
       def test_nested_element__locator__proc
@@ -336,27 +336,27 @@ module AePageObjects
         tail_page_object = mock
         capybara_stub.session.expects(:find).with("#tail_attributes").returns(tail_page_object)
 
-        tail = verify_field_with_intermediary_class(jon, :tail, AePageObjects::Element, tail_page_object)
+        tail = verify_element_on_parent_with_intermediary_class(jon, :tail, AePageObjects::Element, tail_page_object)
 
         color_page_object = mock
         tail_page_object.expects(:find).with("#tail_attributes_color").returns(color_page_object)
-        verify_field(tail, :color, AePageObjects::Element, color_page_object)
+        verify_element_on_parent(tail, :color, AePageObjects::Element, color_page_object)
 
         size_page_object = mock
         tail_page_object.expects(:find).with("#tail_attributes_size_attributes").returns(size_page_object)
-        size = verify_field_with_intermediary_class(tail, :size, AePageObjects::Element, size_page_object)
+        size = verify_element_on_parent_with_intermediary_class(tail, :size, AePageObjects::Element, size_page_object)
 
         assert_equal "Growing!", size.grow!
 
         length_page_object = mock
         size_page_object.expects(:find).with("#tail_attributes_size_attributes_length").returns(length_page_object)
-        verify_field(size, :length, AePageObjects::Element, length_page_object)
+        verify_element_on_parent(size, :length, AePageObjects::Element, length_page_object)
 
         size.expects(:page_local_context).returns("hello")
 
         width_page_object = mock
         size_page_object.expects(:find).with("hello").returns(width_page_object)
-        verify_field(size, :width, AePageObjects::Element, width_page_object)
+        verify_element_on_parent(size, :width, AePageObjects::Element, width_page_object)
       end
 
     private

--- a/test/unit/element_test.rb
+++ b/test/unit/element_test.rb
@@ -1,5 +1,7 @@
 require 'unit_helper'
 
+require 'test_helpers/node_interface_tests'
+
 module AePageObjects
   class ElementTest < AePageObjectsTestCase
     include NodeInterfaceTests

--- a/test/unit/form_dsl_test.rb
+++ b/test/unit/form_dsl_test.rb
@@ -128,13 +128,13 @@ module AePageObjects
         document_stub.stubs(:find).with("#kitty_#{field_method}").returns(field_page_object)
       end
 
-      form = verify_field(kitty, :kitty, kitty.class.element_attributes[:kitty], document_stub)
+      form = verify_element_on_parent(kitty, :kitty, kitty.class.element_attributes[:kitty], document_stub)
 
       field_xpath = "kitty_#{field_method}_xpath"
       field_page_object = mock
       prepare_for_field_reference.call(field_xpath, field_page_object)
       expected_field_type = form.class.element_attributes[field_method]
-      field_node = verify_field(form, field_method, expected_field_type, field_page_object)
+      field_node = verify_element_on_parent(form, field_method, expected_field_type, field_page_object)
 
       prepare_for_field_reference.call(field_xpath, field_page_object)
       assert_nodes_equal field_node, kitty.send(field_method)

--- a/test/unit_helper.rb
+++ b/test/unit_helper.rb
@@ -5,10 +5,10 @@ require 'selenium-webdriver'
 require 'test/unit'
 require "mocha/setup"
 
-Dir[File.join(File.dirname(__FILE__), 'test_helpers', '**', '*.rb')].each {|f| require f}
+require 'test_helpers/element_test_helpers'
 
 class AePageObjectsTestCase < Test::Unit::TestCase
-  include NodeFieldTestHelpers
+  include ElementTestHelpers
 
   undef_method :default_test if method_defined?(:default_test)
 


### PR DESCRIPTION
`Node#element` supports the same arguments as `Node.element` but without the name parameter.

`Node.element` should be used to define static structure of pages that holds for the lifetime of a node instance (an element or document).

`Node#element` should be used to create an `AePageObjects::Element` instance from the current state of the node (element or document). For example, `Node#element` should be used for modals.