### PR TITLE
Use Node#element element factory in readme example

### DIFF
--- a/README.md
+++ b/README.md
@@ -990,12 +990,10 @@ Use ```wait_until_present``` and ```wait_until_absent``` to wait on an element's
 ```ruby
 class AuthorsShowPage < AePageObjects::Document
 
-  element :headshot_viewer, locator: '#head-shots', is: HeadshotViewer
-
   def view_headshots(&block)
     node.click_link("View Headshots")
 
-    viewer = headshot_viewer
+    viewer = element(locator: '#head-shots', is: HeadshotViewer)
     viewer.wait_until_present(10) # wait 10 seconds
 
     yield viewer


### PR DESCRIPTION
Now that #179 is merged, I thought it would be a good idea to update this example to use on-the-fly element creation. This way the page only exposes `headshot_viewer` through the `view_headshots` method (rather than all the time, which isn't accurate).