### PR TITLE
Respect options in item_locator when looking up items in collections

### DIFF
--- a/test/unit/dsl/collection_test.rb
+++ b/test/unit/dsl/collection_test.rb
@@ -24,8 +24,8 @@ module AePageObjects
         previous_owners = verify_element_on_parent_with_intermediary_class(jon, :previous_owners, AePageObjects::Collection, previous_owners_page_object)
 
         first_owner_page_object = mock
-        previous_owners_page_object.expects(:all).with(:xpath,  ".//*").returns([first_owner_page_object])
-        previous_owners_page_object.expects(:find).with(:xpath, ".//*[1]").returns(first_owner_page_object)
+        previous_owners_page_object.expects(:all).with(:xpath,  ".//*", {}).returns([first_owner_page_object])
+        previous_owners_page_object.expects(:find).with(:xpath, ".//*[1]", {}).returns(first_owner_page_object)
         first_owner = verify_item_element_with_intermediary_class(previous_owners, 0, AePageObjects::Element, first_owner_page_object)
 
         owner_name_page_object = mock
@@ -61,8 +61,8 @@ module AePageObjects
 
         first_owner_page_object = mock
 
-        previous_owners_page_object.expects(:all).with(:xpath, ".//*").returns([first_owner_page_object])
-        previous_owners_page_object.expects(:find).with(:xpath, ".//*[1]").returns(first_owner_page_object)
+        previous_owners_page_object.expects(:all).with(:xpath, ".//*", {}).returns([first_owner_page_object])
+        previous_owners_page_object.expects(:find).with(:xpath, ".//*[1]", {}).returns(first_owner_page_object)
         first_owner = verify_item_element_with_intermediary_class(previous_owners, 0, previous_owners_class.item_class, first_owner_page_object)
 
         owner_name_page_object = mock
@@ -97,8 +97,8 @@ module AePageObjects
 
         first_owner_page_object = mock
 
-        previous_owners_page_object.expects(:all).with(:xpath, ".//*").returns([first_owner_page_object])
-        previous_owners_page_object.expects(:find).with(:xpath, ".//*[1]").returns(first_owner_page_object)
+        previous_owners_page_object.expects(:all).with(:xpath, ".//*", {}).returns([first_owner_page_object])
+        previous_owners_page_object.expects(:find).with(:xpath, ".//*[1]", {}).returns(first_owner_page_object)
         first_owner = verify_item_element_with_intermediary_class(previous_owners, 0, previous_owners_class.item_class, first_owner_page_object)
 
         owner_name_page_object = mock
@@ -135,8 +135,8 @@ module AePageObjects
         previous_owners = verify_element_on_parent(jon, :previous_owners, previous_owners_class, previous_owners_page_object)
 
         first_owner_page_object = mock
-        previous_owners_page_object.expects(:all).with(:xpath,  ".//*").returns([first_owner_page_object])
-        previous_owners_page_object.expects(:find).with(:xpath, ".//*[1]").returns(first_owner_page_object)
+        previous_owners_page_object.expects(:all).with(:xpath,  ".//*", {}).returns([first_owner_page_object])
+        previous_owners_page_object.expects(:find).with(:xpath, ".//*[1]", {}).returns(first_owner_page_object)
         first_owner = verify_item_element(previous_owners, 0, previous_owner_class, first_owner_page_object)
 
         owner_name_page_object = mock
@@ -173,8 +173,8 @@ module AePageObjects
         previous_owners = verify_element_on_parent(jon, :previous_owners, previous_owners_class, previous_owners_page_object)
 
         first_owner_page_object = mock
-        previous_owners_page_object.expects(:all).with(:xpath,  ".//*").returns([first_owner_page_object])
-        previous_owners_page_object.expects(:find).with(:xpath, ".//*[1]").returns(first_owner_page_object)
+        previous_owners_page_object.expects(:all).with(:xpath,  ".//*", {}).returns([first_owner_page_object])
+        previous_owners_page_object.expects(:find).with(:xpath, ".//*[1]", {}).returns(first_owner_page_object)
         first_owner = verify_item_element(previous_owners, 0, previous_owner_class, first_owner_page_object)
 
         owner_name_page_object = mock
@@ -209,8 +209,8 @@ module AePageObjects
         previous_owners = verify_element_on_parent_with_intermediary_class(jon, :previous_owners, previous_owners_class, previous_owners_page_object)
 
         first_owner_page_object = mock
-        previous_owners_page_object.expects(:all).with(:xpath,  ".//*").returns([first_owner_page_object])
-        previous_owners_page_object.expects(:find).with(:xpath, ".//*[1]").returns(first_owner_page_object)
+        previous_owners_page_object.expects(:all).with(:xpath,  ".//*", {}).returns([first_owner_page_object])
+        previous_owners_page_object.expects(:find).with(:xpath, ".//*[1]", {}).returns(first_owner_page_object)
         first_owner = verify_item_element(previous_owners, 0, previous_owner_class, first_owner_page_object)
 
         owner_name_page_object = mock
@@ -243,8 +243,8 @@ module AePageObjects
         previous_owners = verify_element_on_parent_with_intermediary_class(jon, :previous_owners, AePageObjects::Collection, previous_owners_page_object)
 
         first_owner_page_object = mock
-        previous_owners_page_object.expects(:all).with(:xpath,  ".//*").returns([first_owner_page_object])
-        previous_owners_page_object.expects(:find).with(:xpath, ".//*[1]").returns(first_owner_page_object)
+        previous_owners_page_object.expects(:all).with(:xpath,  ".//*", {}).returns([first_owner_page_object])
+        previous_owners_page_object.expects(:find).with(:xpath, ".//*[1]", {}).returns(first_owner_page_object)
         first_owner = verify_item_element(previous_owners, 0, previous_owner_class, first_owner_page_object)
 
         owner_name_page_object = mock
@@ -279,8 +279,8 @@ module AePageObjects
         previous_owners = verify_element_on_parent_with_intermediary_class(jon, :previous_owners, AePageObjects::Collection, previous_owners_page_object)
 
         first_owner_page_object = mock
-        previous_owners_page_object.expects(:all).with(:xpath,  ".//*").returns([first_owner_page_object])
-        previous_owners_page_object.expects(:find).with(:xpath, ".//*[1]").returns(first_owner_page_object)
+        previous_owners_page_object.expects(:all).with(:xpath,  ".//*", {}).returns([first_owner_page_object])
+        previous_owners_page_object.expects(:find).with(:xpath, ".//*[1]", {}).returns(first_owner_page_object)
         first_owner = verify_item_element_with_intermediary_class(previous_owners, 0, previous_owner_class, first_owner_page_object)
 
         owner_name_page_object = mock
@@ -322,8 +322,8 @@ module AePageObjects
         previous_owners = verify_element_on_parent_with_intermediary_class(jon, :previous_owners, previous_owners_class, previous_owners_page_object)
 
         first_owner_page_object = mock
-        previous_owners_page_object.expects(:all).with(:xpath,  ".//*").returns([first_owner_page_object])
-        previous_owners_page_object.expects(:find).with(:xpath, ".//*[1]").returns(first_owner_page_object)
+        previous_owners_page_object.expects(:all).with(:xpath,  ".//*", {}).returns([first_owner_page_object])
+        previous_owners_page_object.expects(:find).with(:xpath, ".//*[1]", {}).returns(first_owner_page_object)
         first_owner = verify_item_element_with_intermediary_class(previous_owners, 0, previous_owner_class, first_owner_page_object)
 
         owner_name_page_object = mock
@@ -350,8 +350,8 @@ module AePageObjects
         previous_owners = verify_element_on_parent_with_intermediary_class(jon, :previous_owners, AePageObjects::Collection, previous_owners_page_object)
 
         first_owner_page_object = mock
-        previous_owners_page_object.expects(:all).with(:xpath,  ".//*").returns([first_owner_page_object])
-        previous_owners_page_object.expects(:find).with(:xpath, ".//*[1]").returns(first_owner_page_object)
+        previous_owners_page_object.expects(:all).with(:xpath,  ".//*", {}).returns([first_owner_page_object])
+        previous_owners_page_object.expects(:find).with(:xpath, ".//*[1]", {}).returns(first_owner_page_object)
         first_owner = verify_item_element(previous_owners, 0, AePageObjects::Element, first_owner_page_object)
       end
 
@@ -375,8 +375,8 @@ module AePageObjects
         previous_owners = verify_element_on_parent_with_intermediary_class(jon, :previous_owners, AePageObjects::Collection, previous_owners_page_object)
 
         first_owner_page_object = mock
-        previous_owners_page_object.expects(:all).with(:xpath,  ".//*").returns([first_owner_page_object])
-        previous_owners_page_object.expects(:find).with(:xpath, ".//*[1]").returns(first_owner_page_object)
+        previous_owners_page_object.expects(:all).with(:xpath,  ".//*", {}).returns([first_owner_page_object])
+        previous_owners_page_object.expects(:find).with(:xpath, ".//*[1]", {}).returns(first_owner_page_object)
         first_owner = verify_item_element_with_intermediary_class(previous_owners, 0, AePageObjects::Element, first_owner_page_object)
 
         owner_name_page_object = mock
@@ -410,8 +410,8 @@ module AePageObjects
         previous_owners = verify_element_on_parent_with_intermediary_class(jon, :previous_owners, AePageObjects::Collection, previous_owners_page_object)
 
         first_owner_page_object = mock
-        previous_owners_page_object.expects(:all).with(:xpath,  ".//*").returns([first_owner_page_object])
-        previous_owners_page_object.expects(:find).with(:xpath, ".//*[1]").returns(first_owner_page_object)
+        previous_owners_page_object.expects(:all).with(:xpath,  ".//*", {}).returns([first_owner_page_object])
+        previous_owners_page_object.expects(:find).with(:xpath, ".//*[1]", {}).returns(first_owner_page_object)
         first_owner = verify_item_element_with_intermediary_class(previous_owners, 0, AePageObjects::Element, first_owner_page_object)
 
         owner_name_page_object = mock


### PR DESCRIPTION
Currently any options passed in `item_locator` for collections are ignored.

For example, given a collection where we only want the visible elements:
```ruby
collection :children, item_locator: ['li', { visible: true }]
```

where the markup looks something like this:
```html
<ul>
  <li>First Child</li>
  <li style="display:none">Second Child</li>
  <li>Third Child</li>
</ul>
```

then `children.size` will run the query `[:xpath, './/li']` to look up children and `[:xpath, './/li[2]']` to find the second child.  This causes two problems:
```ruby
  children.size == 3 # should be 2
  children[1].text == 'Second Child' # shoud be 'Third Child'
```

This PR changes the behavior to pass options through when looking up children.  That means now `children.size` will run the query `[:xpath, './/li', { visible: true }]` to look up children and `[:xpath, './/li[2]', { visible: true }]` to find the second child.  So now
```ruby
  1. children.size == 2
  2. children[1].text == 'Third Child'
```