### PR TITLE
Use {exact: true} only for XPath selectors

### DIFF
--- a/lib/ae_page_objects/elements/collection.rb
+++ b/lib/ae_page_objects/elements/collection.rb
@@ -66,9 +66,19 @@ module AePageObjects
 
     def item_xpath
       @item_xpath ||= begin
-        evaled_locator = eval_locator(@item_locator)
-        
-        query_args = evaled_locator + [{:exact => true}]
+        query_args = eval_locator(@item_locator)
+
+        #
+        # Use the { exact: true } setting for XPath selectors that use "XPath.is".  For example, given the XPath
+        #   XPath::HTML.descendant(:div)[XPath.text.is('Example Text')]
+        # the resulting path will be
+        #   .//div[./text() = 'Example Text']
+        # instead of
+        #   .//div[contains(./text(), 'Example Text')]
+        # See https://github.com/jnicklas/capybara#exactness for more information.
+        #
+        query_args += [{:exact => true}] if query_args.first.to_sym == :xpath
+
         query = Capybara::Query.new(*query_args)
 
         result = query.xpath

--- a/test/unit/collection_test.rb
+++ b/test/unit/collection_test.rb
@@ -21,6 +21,45 @@ module AePageObjects
       assert_equal ".//*[contains(concat(' ', normalize-space(@class), ' '), ' some_class ')]", magazine.send(:item_xpath)
     end
 
+    def test_xpath_item_locator
+      bullets = Class.new(AePageObjects::Element)
+      clip    = Class.new(AePageObjects::Collection) do
+        self.item_class = bullets
+      end
+
+      parent_node = mock
+      parent = mock
+      parent.stubs(:node).returns(parent_node)
+
+      magazine_node = mock
+      parent_node.expects(:find).with("#18_holder").returns(magazine_node)
+
+      magazine = clip.new(parent, :name => "18_holder", :item_locator => [:xpath, ".//div[text()='Example Text']"])
+
+      assert_equal ".//div[text()='Example Text']", magazine.send(:item_xpath)
+    end
+
+    def test_xpath_item_locator__matches_exact_text
+      bullets = Class.new(AePageObjects::Element)
+      clip    = Class.new(AePageObjects::Collection) do
+        self.item_class = bullets
+      end
+
+      parent_node = mock
+      parent = mock
+      parent.stubs(:node).returns(parent_node)
+
+      magazine_node = mock
+      parent_node.expects(:find).with("#18_holder").returns(magazine_node)
+
+      magazine = clip.new(parent, :name => "18_holder", :item_locator => [
+        :xpath,
+        XPath::HTML.descendant(:div)[XPath.text.is('Example Text')]
+      ])
+
+      assert_equal ".//div[./text() = 'Example Text']", magazine.send(:item_xpath)
+    end
+
     def test_empty
       bullets = Class.new(AePageObjects::Element)
       clip    = Class.new(AePageObjects::Collection) do


### PR DESCRIPTION
The use of `{exact: true}` is currently unclear within `AePageObjects::Collection#item_xpath`

This PR makes the following changes:

- limits the use of `{exact: true}` to XPath selectors only (it has no effect otherwise)
- add comments explaining the use of `{exact: true}`
- add unit tests for XPath selectors and the use of `{exact: true}`