### PR TITLE
Slight performance improvement for AePageObjects::Collection#each

### DIFF
--- a/lib/ae_page_objects/elements/collection.rb
+++ b/lib/ae_page_objects/elements/collection.rb
@@ -35,8 +35,8 @@ module AePageObjects
     end
 
     def each
-      (0..(size - 1)).each do |index|
-        yield at(index)
+      size.times do |index|
+        yield item_at(index)
       end
     end
 


### PR DESCRIPTION
Currently `AePageObjects::Collection#each` uses `#at(index)` for each loop iteration.  This means that the query to determine the collection size will be executed for each iteration of the loop.

This PR changes `AePageObjects::Collection#each` to instead use `#item_at(index)` which skips the unnecessary size check and reduces the total number of queries performed.