### PR TITLE
pk - catch errors in poll_until to prevent errors from being raised without waiting seconds_to_wait

### DIFF
--- a/lib/ae_page_objects.rb
+++ b/lib/ae_page_objects.rb
@@ -3,6 +3,7 @@ require 'capybara/dsl'
 
 require 'ae_page_objects/version'
 require 'ae_page_objects/exceptions'
+require 'ae_page_objects/util/page_polling'
 
 module AePageObjects
   autoload :Node,              'ae_page_objects/node'
@@ -15,6 +16,8 @@ module AePageObjects
   autoload :Checkbox,          'ae_page_objects/elements/checkbox'
 
   class << self
+    include PagePolling
+
     attr_accessor :default_router
 
     def browser
@@ -49,8 +52,6 @@ module AePageObjects
 
       result
     end
-
-    private
 
     def default_max_wait_time
       if Capybara.respond_to?(:default_max_wait_time)

--- a/lib/ae_page_objects/document_loader.rb
+++ b/lib/ae_page_objects/document_loader.rb
@@ -13,8 +13,12 @@ module AePageObjects
       begin
         poll_until do
           @query.conditions.each do |document_condition|
-            if document = @strategy.load_document_with_condition(document_condition)
-              return document
+            begin
+              if document = @strategy.load_document_with_condition(document_condition)
+                return document
+              end
+            rescue => e
+              raise unless catch_poll_util_error?(e)
             end
           end
 

--- a/lib/ae_page_objects/element_proxy.rb
+++ b/lib/ae_page_objects/element_proxy.rb
@@ -127,21 +127,12 @@ module AePageObjects
       @loaded_element = nil
 
       true
-    rescue => e
-      if Capybara.current_session.driver.is_a?(Capybara::Selenium::Driver) &&
-        e.is_a?(Selenium::WebDriver::Error::StaleElementReferenceError)
-
-        # Inconclusive. Leave the handling up to the caller
-        false
-      else
-        raise
-      end
     end
 
     def with_reloaded_element(timeout)
       poll_until(timeout) do
-        reload_conclusive = reload_element
-        reload_conclusive && yield
+        reload_element
+        yield
       end
     end
   end

--- a/lib/ae_page_objects/util/page_polling.rb
+++ b/lib/ae_page_objects/util/page_polling.rb
@@ -1,11 +1,52 @@
 module AePageObjects
   module PagePolling
+    # Quickly polls the block until it returns (as opposed to throwing an exception). Using poll
+    # is a safer alternative to,
+    #
+    # Capybara.using_wait_time(0) do
+    #   has_content?('Admin')
+    # end
+    #
+    # where we want to determine whether 'Admin' is on the page (without waiting for it to appear).
+    # This is often used to switch login / functionality of page objects based on the state of the
+    # page.
+    #
+    # With poll, the above patterns becomes,
+    #
+    # AePageObjects.poll do
+    #   has_content?('Admin')
+    # end
+    def poll(seconds_to_wait = nil, &block)
+      result = nil
+      poll_until(seconds_to_wait) do
+        result = block.call
+        true
+      end
+      result
+    end
 
-    private
+    # Quickly polls the block until it returns something truthy. This is a helper function for
+    # special cases and probably NOT what you want to use. See AePageObjects#wait_until or
+    # #poll.
+    def poll_until(seconds_to_wait = nil, &block)
+      AePageObjects.wait_until(seconds_to_wait) do
+        # Capybara normally catches errors and retries. However, with the wait time of zero,
+        # capybara catches the errors and immediately reraises them. So we have to catch
+        # those errors in the similar fashion to capybara such that we properly can wait the
+        # whole seconds_to_wait.
+        begin
+          Capybara.using_wait_time(0, &block)
+        rescue => e
+          raise unless catch_poll_until_error?(e)
+          nil
+        end
+      end
+    end
 
-    def poll_until(timeout = nil, &block)
-      AePageObjects.wait_until(timeout) do
-        Capybara.using_wait_time(0, &block)
+    def catch_poll_until_error?(error)
+      types = Capybara.current_session.driver.invalid_element_errors + [Capybara::ElementNotFound]
+      types.any? do |type|
+        error.is_a?(type)
       end
     end
   end

--- a/test/unit/element_proxy_test.rb
+++ b/test/unit/element_proxy_test.rb
@@ -1,4 +1,5 @@
 require 'unit_helper'
+require 'ae_page_objects/element_proxy'
 
 module AePageObjects
   class ElementProxyTest < AePageObjectsTestCase
@@ -221,19 +222,6 @@ module AePageObjects
       proxy = new_proxy
 
       element_class.expect_new
-
-      raised = assert_raise ElementNotAbsent do
-        proxy.wait_until_absent
-      end
-
-      assert_include raised.message, element_class.to_s
-    end
-
-    def test_wait_until_absent__unknown
-      proxy = new_proxy
-
-      element_class.expects(:new).raises(Selenium::WebDriver::Error::StaleElementReferenceError)
-      capybara_stub.driver.expects(:is_a?).with(Capybara::Selenium::Driver).returns(true)
 
       raised = assert_raise ElementNotAbsent do
         proxy.wait_until_absent

--- a/test/unit/page_polling_test.rb
+++ b/test/unit/page_polling_test.rb
@@ -2,10 +2,8 @@ require 'unit_helper'
 require 'ae_page_objects/util/page_polling'
 
 class PagePollingTest < AePageObjectsTestCase
-
   class Dummy
     include AePageObjects::PagePolling
-
     def do_the_poll
       poll_until do
         yield
@@ -13,23 +11,59 @@ class PagePollingTest < AePageObjectsTestCase
     end
   end
 
-  def test_poll_until__with_mocks
-    AePageObjects.expects(:wait_until).yields
-    Capybara.expects(:using_wait_time).with(0).yields
+  def setup
+    super
+    stub_capybara
+  end
 
-    block = mock
-    block.expects(:called).times(1)
+  def test_poll_until__should_use_zero_wait_time
+    assert_not_equal 0, AePageObjects.default_max_wait_time
 
-    Dummy.new.do_the_poll do
-      block.called
+    result = do_the_poll do
+      assert_equal 0, AePageObjects.default_max_wait_time
+      :hello
     end
   end
 
-  def test_poll_until__without_mocks
-    result = Dummy.new.do_the_poll do
+  def test_poll_until__should_return_the_result
+    result = do_the_poll do
       :hello
     end
 
     assert_equal :hello, result
+  end
+
+  def test_poll_until__should_retry_poll_until_errors
+    invocation_count = 0
+    result = do_the_poll do
+      invocation_count += 1
+      raise Capybara::ElementNotFound, 'oops' if invocation_count < 3
+      :hello
+    end
+
+    assert_equal 3, invocation_count
+  end
+
+  def test_poll_until__should_raise_non_poll_until_errors
+    invocation_count = 0
+    assert_raises RuntimeError do
+      do_the_poll do
+        invocation_count += 1
+        raise RuntimeError, 'oops' if invocation_count < 3
+        :hello
+      end
+    end
+    assert_equal 1, invocation_count
+  end
+
+  private
+
+  def stub_capybara
+    capybara = capybara_stub
+    capybara.driver.stubs(:invalid_element_errors).returns([])
+  end
+
+  def do_the_poll(&block)
+    Dummy.new.do_the_poll(&block)
   end
 end

--- a/test/unit_helper.rb
+++ b/test/unit_helper.rb
@@ -1,3 +1,4 @@
+$LOAD_PATH.unshift File.expand_path('../../lib', __FILE__)
 require 'ae_page_objects'
 
 require 'selenium-webdriver'


### PR DESCRIPTION
Capybara has a method called `Capybara::Base#synchronize`. This method waits a certain amount of time for a block to be executed without exceptions. It also rescues common exceptions and automatically retries them. All in the name of more stable tests.

AePageObjects includes a helper method `#wait_until` which waits a certain amount of time for a block to return something truthy. 

It also includes the method `#poll_until` (which builds on `#wait_until`) to quickly poll the browser for the truthy answer. It does this with `Capybara.using_time_out(0)`. This method is currently only used internally in AePageObjects to implement `window.change_to` behavior and element proxy behavior. 

The currently implementation (https://github.com/appfolio/ae_page_objects/blob/c17d020c57208f8f40f4925f883c5e6aa4282a0e/lib/ae_page_objects/util/page_polling.rb#L6), however, can lead to flaky tests. The problem lies with the use of `Capybara.using_time_out(0)`, which causes `Capybara::Base#synchronize` to not rescue any common exceptions (and instead letting them be raised). This means that `window.change_to` can raise exceptions instead of retrying to evaluate its conditions until one of them evaluates to true.

This problem can be seen in the other usage of `#poll_until` in element proxy (https://github.com/appfolio/ae_page_objects/blob/c17d020c57208f8f40f4925f883c5e6aa4282a0e/lib/ae_page_objects/element_proxy.rb#L142). Note, how `#reload_element` tries to catch and retry `Selenium::WebDriver::Error::StaleElementReferenceError`. 

This PRs improves `#poll_until` method to rescue and retry common errors (much like `Capybara::Base#synchronize`). This allows to wait the appropriate amount of time for the page / browser to "settle" down and allow us to evaluate the conditions properly.

This PRs also introduces `#poll` method as a safer alternative to the following pattern,
```ruby
Capybara.using_wait_time(0) do
  po.has_content?('Admin')
end 
```
This is commonly used to try to determine whether a page is in a certain state (without having to wait for that state to become true) in order to switch page object functionality. For example, accessing the main nav actions on mobile may be slightly different then accessing nav actions on desktop. The page object can abstract these differences from the actual tests but it needs a way to quickly determine which version of the page we're using.

 
