### PR TITLE
xw - increase wait_until time when loading a page

### DIFF
--- a/lib/ae_page_objects/document_loader.rb
+++ b/lib/ae_page_objects/document_loader.rb
@@ -7,7 +7,7 @@ module AePageObjects
 
     def load
       begin
-        AePageObjects.wait_until do
+        AePageObjects.wait_until(10) do
           @query.conditions.each do |document_condition|
             if document = @strategy.load_document_with_condition(document_condition)
               return document


### PR DESCRIPTION
This change is due to the flakey tests [test_​clickable_​links_​for__​cash_​flow](https://ci.appfolio.net/project.html?projectId=ApmBundle&buildTypeId=&tab=testDetails&testNameId=9167012763810146378&order=TEST_STATUS_DESC&branch_ApmBundle=__all_branches__&itemsCount=50) and [test_clickable_links_for__income_statement](https://ci.appfolio.net/project.html?projectId=ApmBundle&testNameId=9176217684883626536&tab=testDetails)

 