### PR TITLE
Fix bug in collection item xpath generation

### DIFF
--- a/lib/ae_page_objects/elements/collection.rb
+++ b/lib/ae_page_objects/elements/collection.rb
@@ -106,7 +106,7 @@ module AePageObjects
     end
 
     def item_locator_at(index)
-      [:xpath, "#{item_xpath}[#{index + 1}]", options]
+      [:xpath, "(#{item_xpath})[#{index + 1}]", options]
     end
 
     def default_item_locator

--- a/test/test_apps/shared/test/page_objects/authors/new_page.rb
+++ b/test/test_apps/shared/test/page_objects/authors/new_page.rb
@@ -11,7 +11,7 @@ module PageObjects
         collection :books,
                    :name         => "books_attributes",
                    :locator      => "#author_books",
-                   :item_locator => ".some-books-fool .row" do
+                   :item_locator => ".a-book-fool" do
           element :title
         end
       end

--- a/test/test_apps/shared/views/authors/_form.html.erb
+++ b/test/test_apps/shared/views/authors/_form.html.erb
@@ -20,7 +20,7 @@
   <a class="show_star">Show Star</a>
   <a class="add_star">Add Star</a>
   <a class="remove_star">Remove Star</a>
-  
+
   <span class="star">*</span>
 </div>
 
@@ -41,17 +41,17 @@
   <%= f.text_field :last_name %>
 
   <div id="author_books">
-    <div class="some-books-fool">
-      <%= f.fields_for :books do |book_form| %>
-        <div class="row">
+    <%= f.fields_for :books do |book_form| %>
+      <div class="a-book-fool-parent">
+        <div class="a-book-fool">
           <%= book_form.label :title %>
           <%= book_form.text_field :title %>
           <%= book_form.fields_for :index do |index_form| %>
             <%= index_form.text_field :pages %>
           <% end %>
         </div>
-      <% end %>
-    </div>
+      </div>
+    <% end %>
   </div>
 
   <%= f.submit %>

--- a/test/unit/collection_test.rb
+++ b/test/unit/collection_test.rb
@@ -97,7 +97,7 @@ module AePageObjects
 
       bullet1_stub = mock(:allow_reload!)
       magazine_node.expects(:all).with(:xpath, 'item_xpath', {}).returns([bullet1_stub])
-      magazine_node.expects(:first).with(:xpath, 'item_xpath[1]', {}).returns(bullet1_stub)
+      magazine_node.expects(:first).with(:xpath, '(item_xpath)[1]', {}).returns(bullet1_stub)
       assert_equal bullet1_stub, magazine.at(0).node
     end
 
@@ -116,7 +116,7 @@ module AePageObjects
 
       bullet1_stub = mock(:allow_reload!)
       magazine_node.expects(:all).with(:xpath, 'item_xpath', { :capybara => 'options' }).returns([bullet1_stub])
-      magazine_node.expects(:first).with(:xpath, "item_xpath[1]", { :capybara => 'options' }).returns(bullet1_stub)
+      magazine_node.expects(:first).with(:xpath, "(item_xpath)[1]", { :capybara => 'options' }).returns(bullet1_stub)
       assert_equal bullet1_stub, magazine.at(0).node
     end
 
@@ -173,8 +173,8 @@ module AePageObjects
 
       assert_equal 2, magazine.size
 
-      magazine_node.expects(:first).with(:xpath, "item_xpath[1]", {}).returns(bullet1_stub)
-      magazine_node.expects(:first).with(:xpath, "item_xpath[2]", {}).returns(bullet2_stub)
+      magazine_node.expects(:first).with(:xpath, "(item_xpath)[1]", {}).returns(bullet1_stub)
+      magazine_node.expects(:first).with(:xpath, "(item_xpath)[2]", {}).returns(bullet2_stub)
       each_block_call_count = 0
       magazine.each do |bullet|
         bullet.name
@@ -182,16 +182,16 @@ module AePageObjects
       end
       assert_equal 2, each_block_call_count
 
-      magazine_node.expects(:first).with(:xpath, "item_xpath[1]", {}).times(2).returns(bullet1_stub)
+      magazine_node.expects(:first).with(:xpath, "(item_xpath)[1]", {}).times(2).returns(bullet1_stub)
       assert_equal bullet1_stub, magazine.at(0).node
       assert_equal bullet1_stub, magazine.first.node
 
-      magazine_node.expects(:first).with(:xpath, "item_xpath[2]", {}).times(2).returns(bullet2_stub)
+      magazine_node.expects(:first).with(:xpath, "(item_xpath)[2]", {}).times(2).returns(bullet2_stub)
       assert_equal bullet2_stub, magazine.at(1).node
       assert_equal bullet2_stub, magazine.last.node
 
-      magazine_node.expects(:first).with(:xpath, "item_xpath[1]", {}).returns(bullet1_stub)
-      magazine_node.expects(:first).with(:xpath, "item_xpath[2]", {}).returns(bullet2_stub)
+      magazine_node.expects(:first).with(:xpath, "(item_xpath)[1]", {}).returns(bullet1_stub)
+      magazine_node.expects(:first).with(:xpath, "(item_xpath)[2]", {}).returns(bullet2_stub)
       assert_equal [bullet1_stub, bullet2_stub], magazine.map(&:node)
 
       assert_equal nil, magazine.at(1000)

--- a/test/unit/dsl/collection_test.rb
+++ b/test/unit/dsl/collection_test.rb
@@ -25,7 +25,7 @@ module AePageObjects
 
         first_owner_page_object = stub(:allow_reload!)
         previous_owners_page_object.expects(:all).with(:xpath,  ".//*", {}).returns([first_owner_page_object])
-        previous_owners_page_object.expects(:first).with(:xpath, ".//*[1]", {}).returns(first_owner_page_object)
+        previous_owners_page_object.expects(:first).with(:xpath, "(.//*)[1]", {}).returns(first_owner_page_object)
         first_owner = verify_item_element_with_intermediary_class(previous_owners, 0, AePageObjects::Element, first_owner_page_object)
 
         owner_name_page_object = stub(:allow_reload!)
@@ -62,7 +62,7 @@ module AePageObjects
         first_owner_page_object = stub(:allow_reload!)
 
         previous_owners_page_object.expects(:all).with(:xpath, ".//*", {}).returns([first_owner_page_object])
-        previous_owners_page_object.expects(:first).with(:xpath, ".//*[1]", {}).returns(first_owner_page_object)
+        previous_owners_page_object.expects(:first).with(:xpath, "(.//*)[1]", {}).returns(first_owner_page_object)
         first_owner = verify_item_element_with_intermediary_class(previous_owners, 0, previous_owners_class.item_class, first_owner_page_object)
 
         owner_name_page_object = stub(:allow_reload!)
@@ -98,7 +98,7 @@ module AePageObjects
         first_owner_page_object = stub(:allow_reload!)
 
         previous_owners_page_object.expects(:all).with(:xpath, ".//*", {}).returns([first_owner_page_object])
-        previous_owners_page_object.expects(:first).with(:xpath, ".//*[1]", {}).returns(first_owner_page_object)
+        previous_owners_page_object.expects(:first).with(:xpath, "(.//*)[1]", {}).returns(first_owner_page_object)
         first_owner = verify_item_element_with_intermediary_class(previous_owners, 0, previous_owners_class.item_class, first_owner_page_object)
 
         owner_name_page_object = stub(:allow_reload!)
@@ -136,7 +136,7 @@ module AePageObjects
 
         first_owner_page_object = stub(:allow_reload!)
         previous_owners_page_object.expects(:all).with(:xpath,  ".//*", {}).returns([first_owner_page_object])
-        previous_owners_page_object.expects(:first).with(:xpath, ".//*[1]", {}).returns(first_owner_page_object)
+        previous_owners_page_object.expects(:first).with(:xpath, "(.//*)[1]", {}).returns(first_owner_page_object)
         first_owner = verify_item_element(previous_owners, 0, previous_owner_class, first_owner_page_object)
 
         owner_name_page_object = stub(:allow_reload!)
@@ -174,7 +174,7 @@ module AePageObjects
 
         first_owner_page_object = stub(:allow_reload!)
         previous_owners_page_object.expects(:all).with(:xpath,  ".//*", {}).returns([first_owner_page_object])
-        previous_owners_page_object.expects(:first).with(:xpath, ".//*[1]", {}).returns(first_owner_page_object)
+        previous_owners_page_object.expects(:first).with(:xpath, "(.//*)[1]", {}).returns(first_owner_page_object)
         first_owner = verify_item_element(previous_owners, 0, previous_owner_class, first_owner_page_object)
 
         owner_name_page_object = stub(:allow_reload!)
@@ -210,7 +210,7 @@ module AePageObjects
 
         first_owner_page_object = stub(:allow_reload!)
         previous_owners_page_object.expects(:all).with(:xpath,  ".//*", {}).returns([first_owner_page_object])
-        previous_owners_page_object.expects(:first).with(:xpath, ".//*[1]", {}).returns(first_owner_page_object)
+        previous_owners_page_object.expects(:first).with(:xpath, "(.//*)[1]", {}).returns(first_owner_page_object)
         first_owner = verify_item_element(previous_owners, 0, previous_owner_class, first_owner_page_object)
 
         owner_name_page_object = stub(:allow_reload!)
@@ -244,7 +244,7 @@ module AePageObjects
 
         first_owner_page_object = stub(:allow_reload!)
         previous_owners_page_object.expects(:all).with(:xpath,  ".//*", {}).returns([first_owner_page_object])
-        previous_owners_page_object.expects(:first).with(:xpath, ".//*[1]", {}).returns(first_owner_page_object)
+        previous_owners_page_object.expects(:first).with(:xpath, "(.//*)[1]", {}).returns(first_owner_page_object)
         first_owner = verify_item_element(previous_owners, 0, previous_owner_class, first_owner_page_object)
 
         owner_name_page_object = stub(:allow_reload!)
@@ -280,7 +280,7 @@ module AePageObjects
 
         first_owner_page_object = stub(:allow_reload!)
         previous_owners_page_object.expects(:all).with(:xpath,  ".//*", {}).returns([first_owner_page_object])
-        previous_owners_page_object.expects(:first).with(:xpath, ".//*[1]", {}).returns(first_owner_page_object)
+        previous_owners_page_object.expects(:first).with(:xpath, "(.//*)[1]", {}).returns(first_owner_page_object)
         first_owner = verify_item_element_with_intermediary_class(previous_owners, 0, previous_owner_class, first_owner_page_object)
 
         owner_name_page_object = stub(:allow_reload!)
@@ -323,7 +323,7 @@ module AePageObjects
 
         first_owner_page_object = stub(:allow_reload!)
         previous_owners_page_object.expects(:all).with(:xpath,  ".//*", {}).returns([first_owner_page_object])
-        previous_owners_page_object.expects(:first).with(:xpath, ".//*[1]", {}).returns(first_owner_page_object)
+        previous_owners_page_object.expects(:first).with(:xpath, "(.//*)[1]", {}).returns(first_owner_page_object)
         first_owner = verify_item_element_with_intermediary_class(previous_owners, 0, previous_owner_class, first_owner_page_object)
 
         owner_name_page_object = stub(:allow_reload!)
@@ -351,7 +351,7 @@ module AePageObjects
 
         first_owner_page_object = stub(:allow_reload!)
         previous_owners_page_object.expects(:all).with(:xpath,  ".//*", {}).returns([first_owner_page_object])
-        previous_owners_page_object.expects(:first).with(:xpath, ".//*[1]", {}).returns(first_owner_page_object)
+        previous_owners_page_object.expects(:first).with(:xpath, "(.//*)[1]", {}).returns(first_owner_page_object)
         first_owner = verify_item_element(previous_owners, 0, AePageObjects::Element, first_owner_page_object)
       end
 
@@ -376,7 +376,7 @@ module AePageObjects
 
         first_owner_page_object = stub(:allow_reload!)
         previous_owners_page_object.expects(:all).with(:xpath,  ".//*", {}).returns([first_owner_page_object])
-        previous_owners_page_object.expects(:first).with(:xpath, ".//*[1]", {}).returns(first_owner_page_object)
+        previous_owners_page_object.expects(:first).with(:xpath, "(.//*)[1]", {}).returns(first_owner_page_object)
         first_owner = verify_item_element_with_intermediary_class(previous_owners, 0, AePageObjects::Element, first_owner_page_object)
 
         owner_name_page_object = stub(:allow_reload!)
@@ -411,7 +411,7 @@ module AePageObjects
 
         first_owner_page_object = stub(:allow_reload!)
         previous_owners_page_object.expects(:all).with(:xpath,  ".//*", {}).returns([first_owner_page_object])
-        previous_owners_page_object.expects(:first).with(:xpath, ".//*[1]", {}).returns(first_owner_page_object)
+        previous_owners_page_object.expects(:first).with(:xpath, "(.//*)[1]", {}).returns(first_owner_page_object)
         first_owner = verify_item_element_with_intermediary_class(previous_owners, 0, AePageObjects::Element, first_owner_page_object)
 
         owner_name_page_object = stub(:allow_reload!)


### PR DESCRIPTION
Without the parentheses, this xpath selector calculation is incorrect. As an example, lets say the item_xpath evaluates as ".//someLocator[1]". What this selector is actually specifying is: find all someLocator elements under the current node that are the first child of their parent element. What we really want to say is: find exactly the first someLocator element. In order to get this behavior, we need to wrap the part of the locator that is not the array indexing in parentheses, due to the order of precendence of the xpath operators ([] has higher precedence than //).