### PR TITLE
Reload elements on StaleElementReferenceError

### DIFF
--- a/lib/ae_page_objects/element.rb
+++ b/lib/ae_page_objects/element.rb
@@ -73,6 +73,13 @@ module AePageObjects
       @locator == default_locator
     end
 
+    def reload_descendents
+      parent.reload_descendents if parent.respond_to?(:reload_descendents)
+      @node  = scoped_node
+      @stale = false
+      ensure_loaded!
+    end
+
   private
 
     def configure(options)

--- a/lib/ae_page_objects/element_proxy.rb
+++ b/lib/ae_page_objects/element_proxy.rb
@@ -99,6 +99,11 @@ module AePageObjects
       end
 
       implicit_element.__send__(name, *args, &block)
+    rescue Selenium::WebDriver::Error::StaleElementReferenceError
+      # A StaleElementReferenceError can occur when a selenium node is referenced but is no longer attached to the DOM.
+      # In this case we need to work our way up the element tree to make sure we are referencing the latest DOM nodes.
+      implicit_element.reload_descendents
+      retry
     end
 
     def respond_to?(*args)

--- a/test/test_apps/shared/test/selenium/page_object_integration_test.rb
+++ b/test/test_apps/shared/test/selenium/page_object_integration_test.rb
@@ -621,6 +621,24 @@ class PageObjectIntegrationTest < Selenium::TestCase
     assert_windows(window1, window2, current: window1)
   end
 
+  def test_element_reload_descendents
+    new_author_page = PageObjects::Authors::NewPage.visit
+    new_author_page.first_name.set "Michael"
+
+    # Cache the nested `books` collection
+    books = new_author_page.books
+    books.at(0).title.set 'something else'
+
+    # Reload the page. The cached node in the `books` collection is now obsolete
+    Capybara.current_session.driver.execute_script('location.reload(true)')
+    AePageObjects.wait_until { new_author_page.first_name.value.blank? }
+
+    # After reload the correct element should be found
+    assert_nothing_raised do
+      assert_equal '', books.at(0).title.value
+    end
+  end
+
 private
 
   def assert_windows(*windows)


### PR DESCRIPTION
This PR fixes an issue where in some conditions `Selenium::WebDriver::Error::StaleElementReferenceError` is thrown.

The problem occurs when a test stores a deeply nested instance of `AePageObjects::Element` in a variable, reloads the page, and then continues to use that element.  Because the element references a capybara node that is obsolete the error above can occur.

The solution is to detect this scenario and then traverse back up to the root node of the tree and reload elements.

See https://github.com/appfolio/ae_page_objects/pull/202/files#diff-941de1d6909262810f79a64585c03622R624 for an example test case that reproduces the problem.