### PR TITLE
Fix typo in Document#reload

### DIFF
--- a/lib/ae_page_objects/document.rb
+++ b/lib/ae_page_objects/document.rb
@@ -73,7 +73,7 @@ module AePageObjects
         location.reload(true);
       SCRIPT
 
-      element('body.reloading').wait_until_absent(timeout)
+      element('body.ae_page_objects-reloading').wait_until_absent(timeout)
       ensure_loaded!
       self
     end

--- a/test/unit/document_test.rb
+++ b/test/unit/document_test.rb
@@ -159,7 +159,7 @@ module AePageObjects
       kitty_page
         .node
         .expects(:first)
-        .with('body.reloading', minimum: 0)
+        .with('body.ae_page_objects-reloading', minimum: 0)
         .times(4)
         .returns(capybara_node, capybara_node, capybara_node, nil)
 


### PR DESCRIPTION
This PR fixes a typo in `Document#reload`