### PR TITLE
Prevent AePageObjects::Collection#size from waiting

### DIFF
--- a/lib/ae_page_objects/elements/collection.rb
+++ b/lib/ae_page_objects/elements/collection.rb
@@ -41,7 +41,19 @@ module AePageObjects
     end
 
     def size
-      node.all(:xpath, item_xpath, options.merge(wait: false)).size
+      #
+      # In some cases when #size is called while the DOM is updating, Capybara
+      # will catch (and swallow) underlying exceptions such as
+      # `Selenium::WebDriver::Error::StaleElementReferenceError`.
+      # When this happens it will wait up to the max wait time, which can cause
+      # issues for `AePageObjects.wait_until` blocks.
+      #
+      # To prevent this issue the #all and #size calls are made with the Capybara
+      # wait time set to 0.
+      #
+      Capybara.using_wait_time(0) do
+        node.all(:xpath, item_xpath, options).size
+      end
     end
 
     def last

--- a/test/unit/collection_test.rb
+++ b/test/unit/collection_test.rb
@@ -96,7 +96,7 @@ module AePageObjects
       magazine.stubs(:item_xpath).returns('item_xpath')
 
       bullet1_stub = mock(:allow_reload!)
-      magazine_node.expects(:all).with(:xpath, 'item_xpath', wait: false).returns([bullet1_stub])
+      magazine_node.expects(:all).with(:xpath, 'item_xpath', {}).returns([bullet1_stub])
       magazine_node.expects(:first).with(:xpath, '(item_xpath)[1]', minimum: 0).returns(bullet1_stub)
       assert_equal bullet1_stub, magazine.at(0).node
     end
@@ -115,7 +115,7 @@ module AePageObjects
       magazine.stubs(:item_xpath).returns("item_xpath")
 
       bullet1_stub = mock(:allow_reload!)
-      magazine_node.expects(:all).with(:xpath, 'item_xpath', { capybara: 'options', wait: false }).returns([bullet1_stub])
+      magazine_node.expects(:all).with(:xpath, 'item_xpath', { capybara: 'options' }).returns([bullet1_stub])
       magazine_node.expects(:first).with(:xpath, "(item_xpath)[1]", { capybara: 'options', minimum: 0 }).returns(bullet1_stub)
       assert_equal bullet1_stub, magazine.at(0).node
     end
@@ -136,7 +136,7 @@ module AePageObjects
       magazine = clip.new(parent, :name => "18_holder")
       magazine.stubs(:item_xpath).returns("item_xpath")
 
-      magazine_node.stubs(:all).with(:xpath, "item_xpath", wait: false).returns([])
+      magazine_node.stubs(:all).with(:xpath, "item_xpath", {}).returns([])
 
       assert_equal 0, magazine.size
 
@@ -169,7 +169,7 @@ module AePageObjects
 
       bullet1_stub = stub(:allow_reload!)
       bullet2_stub = stub(:allow_reload!)
-      magazine_node.stubs(:all).with(:xpath, "item_xpath", wait: false).returns([bullet1_stub, bullet2_stub])
+      magazine_node.stubs(:all).with(:xpath, "item_xpath", {}).returns([bullet1_stub, bullet2_stub])
 
       assert_equal 2, magazine.size
 

--- a/test/unit/dsl/collection_test.rb
+++ b/test/unit/dsl/collection_test.rb
@@ -24,7 +24,7 @@ module AePageObjects
         previous_owners = verify_element_on_parent_with_intermediary_class(jon, :previous_owners, AePageObjects::Collection, previous_owners_page_object)
 
         first_owner_page_object = stub(:allow_reload!)
-        previous_owners_page_object.expects(:all).with(:xpath,  ".//*", wait: false).returns([first_owner_page_object])
+        previous_owners_page_object.expects(:all).with(:xpath,  ".//*", {}).returns([first_owner_page_object])
         previous_owners_page_object.expects(:first).with(:xpath, "(.//*)[1]", minimum: 0).returns(first_owner_page_object)
         first_owner = verify_item_element_with_intermediary_class(previous_owners, 0, AePageObjects::Element, first_owner_page_object)
 
@@ -61,7 +61,7 @@ module AePageObjects
 
         first_owner_page_object = stub(:allow_reload!)
 
-        previous_owners_page_object.expects(:all).with(:xpath, ".//*", wait: false).returns([first_owner_page_object])
+        previous_owners_page_object.expects(:all).with(:xpath, ".//*", {}).returns([first_owner_page_object])
         previous_owners_page_object.expects(:first).with(:xpath, "(.//*)[1]", minimum: 0).returns(first_owner_page_object)
         first_owner = verify_item_element_with_intermediary_class(previous_owners, 0, previous_owners_class.item_class, first_owner_page_object)
 
@@ -97,7 +97,7 @@ module AePageObjects
 
         first_owner_page_object = stub(:allow_reload!)
 
-        previous_owners_page_object.expects(:all).with(:xpath, ".//*", wait: false).returns([first_owner_page_object])
+        previous_owners_page_object.expects(:all).with(:xpath, ".//*", {}).returns([first_owner_page_object])
         previous_owners_page_object.expects(:first).with(:xpath, "(.//*)[1]", minimum: 0).returns(first_owner_page_object)
         first_owner = verify_item_element_with_intermediary_class(previous_owners, 0, previous_owners_class.item_class, first_owner_page_object)
 
@@ -135,7 +135,7 @@ module AePageObjects
         previous_owners = verify_element_on_parent(jon, :previous_owners, previous_owners_class, previous_owners_page_object)
 
         first_owner_page_object = stub(:allow_reload!)
-        previous_owners_page_object.expects(:all).with(:xpath,  ".//*", wait: false).returns([first_owner_page_object])
+        previous_owners_page_object.expects(:all).with(:xpath,  ".//*", {}).returns([first_owner_page_object])
         previous_owners_page_object.expects(:first).with(:xpath, "(.//*)[1]", minimum: 0).returns(first_owner_page_object)
         first_owner = verify_item_element(previous_owners, 0, previous_owner_class, first_owner_page_object)
 
@@ -173,7 +173,7 @@ module AePageObjects
         previous_owners = verify_element_on_parent(jon, :previous_owners, previous_owners_class, previous_owners_page_object)
 
         first_owner_page_object = stub(:allow_reload!)
-        previous_owners_page_object.expects(:all).with(:xpath,  ".//*", wait: false).returns([first_owner_page_object])
+        previous_owners_page_object.expects(:all).with(:xpath,  ".//*", {}).returns([first_owner_page_object])
         previous_owners_page_object.expects(:first).with(:xpath, "(.//*)[1]", minimum: 0).returns(first_owner_page_object)
         first_owner = verify_item_element(previous_owners, 0, previous_owner_class, first_owner_page_object)
 
@@ -209,7 +209,7 @@ module AePageObjects
         previous_owners = verify_element_on_parent_with_intermediary_class(jon, :previous_owners, previous_owners_class, previous_owners_page_object)
 
         first_owner_page_object = stub(:allow_reload!)
-        previous_owners_page_object.expects(:all).with(:xpath,  ".//*", wait: false).returns([first_owner_page_object])
+        previous_owners_page_object.expects(:all).with(:xpath,  ".//*", {}).returns([first_owner_page_object])
         previous_owners_page_object.expects(:first).with(:xpath, "(.//*)[1]", minimum: 0).returns(first_owner_page_object)
         first_owner = verify_item_element(previous_owners, 0, previous_owner_class, first_owner_page_object)
 
@@ -243,7 +243,7 @@ module AePageObjects
         previous_owners = verify_element_on_parent_with_intermediary_class(jon, :previous_owners, AePageObjects::Collection, previous_owners_page_object)
 
         first_owner_page_object = stub(:allow_reload!)
-        previous_owners_page_object.expects(:all).with(:xpath,  ".//*", wait: false).returns([first_owner_page_object])
+        previous_owners_page_object.expects(:all).with(:xpath,  ".//*", {}).returns([first_owner_page_object])
         previous_owners_page_object.expects(:first).with(:xpath, "(.//*)[1]", minimum: 0).returns(first_owner_page_object)
         first_owner = verify_item_element(previous_owners, 0, previous_owner_class, first_owner_page_object)
 
@@ -279,7 +279,7 @@ module AePageObjects
         previous_owners = verify_element_on_parent_with_intermediary_class(jon, :previous_owners, AePageObjects::Collection, previous_owners_page_object)
 
         first_owner_page_object = stub(:allow_reload!)
-        previous_owners_page_object.expects(:all).with(:xpath,  ".//*", wait: false).returns([first_owner_page_object])
+        previous_owners_page_object.expects(:all).with(:xpath,  ".//*", {}).returns([first_owner_page_object])
         previous_owners_page_object.expects(:first).with(:xpath, "(.//*)[1]", minimum: 0).returns(first_owner_page_object)
         first_owner = verify_item_element_with_intermediary_class(previous_owners, 0, previous_owner_class, first_owner_page_object)
 
@@ -322,7 +322,7 @@ module AePageObjects
         previous_owners = verify_element_on_parent_with_intermediary_class(jon, :previous_owners, previous_owners_class, previous_owners_page_object)
 
         first_owner_page_object = stub(:allow_reload!)
-        previous_owners_page_object.expects(:all).with(:xpath,  ".//*", wait: false).returns([first_owner_page_object])
+        previous_owners_page_object.expects(:all).with(:xpath,  ".//*", {}).returns([first_owner_page_object])
         previous_owners_page_object.expects(:first).with(:xpath, "(.//*)[1]", minimum: 0).returns(first_owner_page_object)
         first_owner = verify_item_element_with_intermediary_class(previous_owners, 0, previous_owner_class, first_owner_page_object)
 
@@ -350,7 +350,7 @@ module AePageObjects
         previous_owners = verify_element_on_parent_with_intermediary_class(jon, :previous_owners, AePageObjects::Collection, previous_owners_page_object)
 
         first_owner_page_object = stub(:allow_reload!)
-        previous_owners_page_object.expects(:all).with(:xpath,  ".//*", wait: false).returns([first_owner_page_object])
+        previous_owners_page_object.expects(:all).with(:xpath,  ".//*", {}).returns([first_owner_page_object])
         previous_owners_page_object.expects(:first).with(:xpath, "(.//*)[1]", minimum: 0).returns(first_owner_page_object)
         first_owner = verify_item_element(previous_owners, 0, AePageObjects::Element, first_owner_page_object)
       end
@@ -375,7 +375,7 @@ module AePageObjects
         previous_owners = verify_element_on_parent_with_intermediary_class(jon, :previous_owners, AePageObjects::Collection, previous_owners_page_object)
 
         first_owner_page_object = stub(:allow_reload!)
-        previous_owners_page_object.expects(:all).with(:xpath,  ".//*", wait: false).returns([first_owner_page_object])
+        previous_owners_page_object.expects(:all).with(:xpath,  ".//*", {}).returns([first_owner_page_object])
         previous_owners_page_object.expects(:first).with(:xpath, "(.//*)[1]", minimum: 0).returns(first_owner_page_object)
         first_owner = verify_item_element_with_intermediary_class(previous_owners, 0, AePageObjects::Element, first_owner_page_object)
 
@@ -410,7 +410,7 @@ module AePageObjects
         previous_owners = verify_element_on_parent_with_intermediary_class(jon, :previous_owners, AePageObjects::Collection, previous_owners_page_object)
 
         first_owner_page_object = stub(:allow_reload!)
-        previous_owners_page_object.expects(:all).with(:xpath,  ".//*", wait: false).returns([first_owner_page_object])
+        previous_owners_page_object.expects(:all).with(:xpath,  ".//*", {}).returns([first_owner_page_object])
         previous_owners_page_object.expects(:first).with(:xpath, "(.//*)[1]", minimum: 0).returns(first_owner_page_object)
         first_owner = verify_item_element_with_intermediary_class(previous_owners, 0, AePageObjects::Element, first_owner_page_object)
 


### PR DESCRIPTION
An issue has been found where `AePageObjects::Collection#size` waits for up to `Capybara.default_wait_time`. If `#size` is used within an `AePageObjects#wait_until` block it is possible for the block to fail after only 1 iteration.

The solution is to prevent Capybara from waiting within `#size` calls.