### PR TITLE
Remove waiting from ElementProxy methods

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,13 @@
+## Version 5.0.0
+
+### Changed
+
+* [211](https://github.com/appfolio/ae_page_objects/pull/211) Remove waiting from ElementProxy methods
+
+  This change updates the signature and behavior of the `visible?` / `hidden?` / `present?` / `absent?` methods on the `ElementProxy` class.
+  
+  These methods no longer take any arguments and do not wait. To wait for any of the above conditions, users should instead call the `wait_until_*` methods.
+
 ## Version 4.3.0
 
 ### Fixed

--- a/lib/ae_page_objects/element.rb
+++ b/lib/ae_page_objects/element.rb
@@ -89,6 +89,11 @@ module AePageObjects
     def configure(options)
       @locator = options.delete(:locator)
       @name    = options.delete(:name)
+      if options.key?(:wait)
+        @wait = options.delete(:wait)
+      else
+        @wait = true
+      end
 
       @name = @name.to_s if @name
     end
@@ -117,7 +122,12 @@ module AePageObjects
         locator.push(default_options)
       end
 
-      node = AePageObjects.wait_until { parent.node.first(*locator) }
+      if @wait
+        node = AePageObjects.wait_until { parent.node.first(*locator) }
+      else
+        node = parent.node.first(*locator)
+        raise LoadingElementFailed, 'Element Not Found' unless node
+      end
       node.allow_reload!
       node
     rescue AePageObjects::WaitTimeoutError => e

--- a/lib/ae_page_objects/element.rb
+++ b/lib/ae_page_objects/element.rb
@@ -107,20 +107,19 @@ module AePageObjects
 
     def scoped_node
       locator = eval_locator(@locator)
-      if locator.empty?
-        parent.node
-      else
-        default_options = { minimum: 0 }
-        if locator.last.is_a?(::Hash)
-          locator[-1] = default_options.merge(locator.last)
-        else
-          locator.push(default_options)
-        end
 
-        node = AePageObjects.wait_until { parent.node.first(*locator) }
-        node.allow_reload!
-        node
+      return parent.node if locator.empty?
+
+      default_options = { minimum: 0 }
+      if locator.last.is_a?(::Hash)
+        locator[-1] = default_options.merge(locator.last)
+      else
+        locator.push(default_options)
       end
+
+      node = AePageObjects.wait_until { parent.node.first(*locator) }
+      node.allow_reload!
+      node
     rescue AePageObjects::WaitTimeoutError => e
       raise LoadingElementFailed, e.message
     end

--- a/lib/ae_page_objects/element_proxy.rb
+++ b/lib/ae_page_objects/element_proxy.rb
@@ -15,32 +15,22 @@ module AePageObjects
       @loaded_element = nil
     end
 
-    def visible?(options = {})
-      wait_until_visible(options[:wait])
-      true
-    rescue ElementNotVisible
-      false
+    def visible?
+      reload_element
+      @loaded_element&.visible?
     end
 
-    def hidden?(options = {})
-      wait_until_hidden(options[:wait])
-      true
-    rescue ElementNotHidden
-      false
+    def hidden?
+      !visible?
     end
 
-    def present?(options = {})
-      wait_until_present(options[:wait])
-      true
-    rescue ElementNotPresent
-      false
+    def present?
+      reload_element
+      !@loaded_element.nil?
     end
 
-    def absent?(options = {})
-      wait_until_absent(options[:wait])
-      true
-    rescue ElementNotAbsent
-      false
+    def absent?
+      !present?
     end
 
     def presence
@@ -123,8 +113,19 @@ module AePageObjects
 
     private
 
-    def load_element
-      @element_class.new(*@args)
+    def load_element(wait: true)
+      args = @args.dup
+
+      options_or_locator = args.pop
+      options = if options_or_locator.is_a?(Hash)
+                  options_or_locator.merge(wait: wait)
+                else
+                  { locator: options_or_locator, wait: wait }
+                end
+
+      args << options
+
+      @element_class.new(*args)
     end
 
     def implicit_element
@@ -132,7 +133,7 @@ module AePageObjects
     end
 
     def reload_element
-      @loaded_element = load_element
+      @loaded_element = load_element(wait: false)
     rescue LoadingElementFailed
       @loaded_element = nil
     end

--- a/lib/ae_page_objects/version.rb
+++ b/lib/ae_page_objects/version.rb
@@ -1,3 +1,3 @@
 module AePageObjects
-  VERSION = '4.3.0'.freeze
+  VERSION = '5.0.0.pre1'.freeze
 end

--- a/test/test_apps/shared/test/selenium/page_object_integration_test.rb
+++ b/test/test_apps/shared/test/selenium/page_object_integration_test.rb
@@ -174,10 +174,10 @@ class PageObjectIntegrationTest < Selenium::TestCase
   def test_element_proxy
     author = PageObjects::Authors::NewPage.visit
 
-    assert author.rating.star.present?(wait: 1)
-    assert author.rating.star.visible?(wait: 1)
-    refute author.rating.star.absent?(wait: 1)
-    refute author.rating.star.hidden?(wait: 1)
+    assert author.rating.star.present?
+    assert author.rating.star.visible?
+    refute author.rating.star.absent?
+    refute author.rating.star.hidden?
 
     assert_nothing_raised do
       author.rating.star.wait_until_present(0)

--- a/test/test_apps/shared/test/selenium/page_object_integration_test.rb
+++ b/test/test_apps/shared/test/selenium/page_object_integration_test.rb
@@ -509,7 +509,8 @@ class PageObjectIntegrationTest < Selenium::TestCase
     # Setup 4th window to delay displaying last_name
     AuthorsController.last_name_display_delay_ms = (default_wait_time - 2) * 1000
 
-    authors.authors[2].show_in_new_window!
+    paul = authors.authors[2].show_in_new_window_with_name!("Paul")
+    window4 = paul.window
 
     AuthorsController.last_name_display_delay_ms = nil
 
@@ -525,7 +526,7 @@ class PageObjectIntegrationTest < Selenium::TestCase
       end
     end
 
-    window4 = found.window
+    assert_equal window4.handle, found.window.handle
 
     # Firefox opens new tabs adjacent to the current tab so the order of windows is going to be:
     #   window1, window4, window3, window2.

--- a/test/unit/collection_test.rb
+++ b/test/unit/collection_test.rb
@@ -18,7 +18,7 @@ module AePageObjects
 
       magazine = clip.new(parent, :name => "18_holder", :item_locator => ".some_class")
 
-      assert_equal ".//*[contains(concat(' ', normalize-space(@class), ' '), ' some_class ')]", magazine.send(:item_xpath)
+      assert_equal ".//*[contains(concat(' ',normalize-space(@class),' '),' some_class ')]", magazine.send(:item_xpath)
     end
 
     def test_xpath_item_locator

--- a/test/unit/element_proxy_test.rb
+++ b/test/unit/element_proxy_test.rb
@@ -40,15 +40,11 @@ module AePageObjects
     def test_visible
       proxy = new_proxy
 
-      element_class.expect_new
+      element_class.expect_new(wait: false)
       element_class.any_instance.expects(:visible?).returns(true)
       assert proxy.visible?
 
-      element_class.expect_new
-      element_class.any_instance.expects(:visible?).returns(true)
-      assert proxy.visible?(wait: 20)
-
-      element_class.expect_new
+      element_class.expect_new(wait: false)
       element_class.any_instance.expects(:visible?).returns(false)
       refute proxy.visible?
     end
@@ -63,15 +59,11 @@ module AePageObjects
     def test_hidden
       proxy = new_proxy
 
-      element_class.expect_new
+      element_class.expect_new(wait: false)
       element_class.any_instance.expects(:visible?).returns(false)
       assert proxy.hidden?
 
-      element_class.expect_new
-      element_class.any_instance.expects(:visible?).returns(false)
-      assert proxy.hidden?(wait: 20)
-
-      element_class.expect_new
+      element_class.expect_new(wait: false)
       element_class.any_instance.expects(:visible?).returns(true)
       assert ! proxy.hidden?
     end
@@ -86,11 +78,8 @@ module AePageObjects
     def test_present
       proxy = new_proxy
 
-      element_class.expect_new
+      element_class.expect_new(wait: false)
       assert proxy.present?
-
-      element_class.expect_new
-      assert proxy.present?(wait: 20)
     end
 
     def test_present__element_not_found
@@ -103,7 +92,7 @@ module AePageObjects
     def test_absent
       proxy = new_proxy
 
-      element_class.expect_new
+      element_class.expect_new(wait: false)
       refute proxy.absent?
     end
 
@@ -112,9 +101,6 @@ module AePageObjects
 
       element_class.expects(:new).raises(AePageObjects::LoadingElementFailed)
       assert proxy.absent?
-
-      element_class.expects(:new).raises(AePageObjects::LoadingElementFailed)
-      assert proxy.absent?(wait: 20)
     end
 
     def test_presence
@@ -134,7 +120,7 @@ module AePageObjects
     def test_wait_until_visible
       proxy = new_proxy
 
-      element_class.expect_new
+      element_class.expect_new(wait: false)
       element_class.any_instance.expects(:visible?).returns(true)
 
       proxy.wait_until_visible
@@ -143,7 +129,7 @@ module AePageObjects
     def test_wait_until_visible__timeout
       proxy = new_proxy
 
-      element_class.expect_new
+      element_class.expect_new(wait: false)
       element_class.any_instance.expects(:visible?).returns(false)
 
       raised = assert_raise ElementNotVisible do
@@ -156,7 +142,7 @@ module AePageObjects
     def test_wait_until_hidden
       proxy = new_proxy
 
-      element_class.expect_new
+      element_class.expect_new(wait: false)
       element_class.any_instance.expects(:visible?).returns(false)
 
       proxy.wait_until_hidden
@@ -165,7 +151,7 @@ module AePageObjects
     def test_wait_until_hidden__timeout
       proxy = new_proxy
 
-      element_class.expect_new
+      element_class.expect_new(wait: false)
       element_class.any_instance.expects(:visible?).returns(true)
 
       raised = assert_raise ElementNotHidden do
@@ -178,7 +164,7 @@ module AePageObjects
     def test_wait_until_present
       proxy = new_proxy
 
-      element_class.expect_new
+      element_class.expect_new(wait: false)
 
       proxy.wait_until_present
     end
@@ -186,7 +172,7 @@ module AePageObjects
     def test_wait_until_present__with_timeout
       proxy = new_proxy
 
-      element_class.expect_new
+      element_class.expect_new(wait: false)
 
       proxy.wait_until_present(20)
     end
@@ -222,7 +208,7 @@ module AePageObjects
     def test_wait_until_absent__present
       proxy = new_proxy
 
-      element_class.expect_new
+      element_class.expect_new(wait: false)
 
       raised = assert_raise ElementNotAbsent do
         proxy.wait_until_absent
@@ -268,14 +254,14 @@ module AePageObjects
 
     def element_class
       @element_class ||= Class.new(Element) do
-        def self.expect_new
-          expects(:new).with(1, 2).returns(self.allocate)
+        def self.expect_new(wait: true)
+          expects(:new).with('mock_parent', { locator: 'mock_locator', wait: wait }).returns(self.allocate)
         end
       end
     end
 
     def new_proxy
-      ElementProxy.new(element_class, 1, 2)
+      ElementProxy.new(element_class, 'mock_parent', 'mock_locator')
     end
 
     def assert_is_proxy(proxy)


### PR DESCRIPTION
The `ElementProxy` class has a set of methods that query the state of the element:

```
visible?
hidden?
present?
absent?
```

These methods all include waiting, so instead of just querying the state they *wait* for the condition to be `true`.

This causes considerable performance issues due to developers not being aware of this behavior. Since we have other methods for waiting for elements to be visible / hidden / present / absent, these methods should not wait at all.