### PR TITLE
Add a textarea element

### DIFF
--- a/lib/ae_page_objects.rb
+++ b/lib/ae_page_objects.rb
@@ -14,6 +14,7 @@ module AePageObjects
   autoload :Form,              'ae_page_objects/elements/form'
   autoload :Select,            'ae_page_objects/elements/select'
   autoload :Checkbox,          'ae_page_objects/elements/checkbox'
+  autoload :Textarea,          'ae_page_objects/elements/textarea'
 
   class << self
     attr_accessor :default_router

--- a/lib/ae_page_objects/elements/textarea.rb
+++ b/lib/ae_page_objects/elements/textarea.rb
@@ -1,0 +1,13 @@
+module AePageObjects
+  class Textarea < Element
+    def set(value)
+      node.set(value, { clear: clear_keys })
+    end
+
+    private
+
+    def clear_keys
+      [[:command, 'a'], :backspace]
+    end
+  end
+end

--- a/test/unit/dsl/element_test.rb
+++ b/test/unit/dsl/element_test.rb
@@ -88,6 +88,23 @@ module AePageObjects
         verify_element_on_parent(jon, :kind, AePageObjects::Checkbox, kind_page_object)
       end
 
+      def test_element__is__textarea
+        kitty = Class.new(AePageObjects::Document) do
+          element :description, is: AePageObjects::Textarea
+        end
+
+        assert kitty.method_defined?(:description)
+        assert_equal [:description], kitty.element_attributes.keys
+
+        stub_current_window
+
+        jon = kitty.new
+
+        description_page_object = stub(:allow_reload!)
+        capybara_stub.session.expects(:first).with("#description", minimum: 0).returns(description_page_object)
+        verify_element_on_parent(jon, :description, AePageObjects::Textarea, description_page_object)
+      end
+
       def test_element__is__special_widget
         special_widget = Class.new(AePageObjects::Element)
 


### PR DESCRIPTION
Add new clear options to set a value for textareas. By default, in
the chrome selenium test, when `set` value of text-related node, it would
only prepend the first line. As the capybara chrome node: it only sends
space and backspace to clear the text. https://bit.ly/3zpJZYJ
However, this will **ONLY** clear the first line of the text area.

In this commit, we added a Textarea element to override the `set` method
to clear all text in the text area.

This is following the set definition in the Capybara: it says we could
use `[[:command, 'a'], :backspace]` to clear all text.
Github capybara/selenium/node.rb#L55: https://bit.ly/3CtlTP3

It works both for firefox and chrome