### PR TITLE
Add Backstage catalog metadata file(s)

### DIFF
--- a/catalog-info.yaml
+++ b/catalog-info.yaml
@@ -1,0 +1,17 @@
+apiVersion: backstage.io/v1alpha1
+kind: Component
+metadata:
+  title: ae_page_objects
+  description: Legacy library which provides a customizable implementation of the
+    Page Object pattern built on top of Capybara to be used in automated
+    acceptance test suites.
+  tags:
+    - oss
+  annotations:
+    appfolio.com/package-location: url:https://rubygems.org/gems/ae_page_objects
+    appfolio.com/package-type: gem
+  name: ae-page-objects
+spec:
+  type: library
+  lifecycle: maintenance
+  owner: apm-test-automation


### PR DESCRIPTION
All Backstage component, resource, and api catalog metadata files are migrating to project repositories to lower the rate of effort for catalog maintenance.

[_Created by Sourcegraph batch change `modethirteen/migrate-developer-portal-catalog-open-source-metadata`._](https://sourcegraph.appf.io/users/modethirteen/batch-changes/migrate-developer-portal-catalog-open-source-metadata)