### PR TITLE
DUX-3335: fix Dependabot security alerts for webpack-dev-server (CVE-2025-30359, CVE-2025-30360)

### DIFF
--- a/test/test_apps/7.2/package.json
+++ b/test/test_apps/7.2/package.json
@@ -10,6 +10,6 @@
   },
   "version": "0.1.0",
   "devDependencies": {
-    "webpack-dev-server": "^3.10.3"
+    "webpack-dev-server": ">=5.2.1"
   }
 }

--- a/test/test_apps/8.0/package.json
+++ b/test/test_apps/8.0/package.json
@@ -10,6 +10,6 @@
   },
   "version": "0.1.0",
   "devDependencies": {
-    "webpack-dev-server": "^3.10.3"
+    "webpack-dev-server": ">=5.2.1"
   }
 }

--- a/test/test_apps/8.1/package.json
+++ b/test/test_apps/8.1/package.json
@@ -10,6 +10,6 @@
   },
   "version": "0.1.0",
   "devDependencies": {
-    "webpack-dev-server": "^3.10.3"
+    "webpack-dev-server": ">=5.2.1"
   }
 }


### PR DESCRIPTION
## Summary

Bumps `webpack-dev-server` constraint from `^3.10.3` to `>=5.2.1` in the three test app `package.json` files to resolve 6 open Dependabot alerts.

### Vulnerabilities fixed

| Alert | Package | Ecosystem | Severity | CVE | Fix |
|-------|---------|-----------|----------|-----|-----|
| #68 | webpack-dev-server | npm | MEDIUM | CVE-2025-30359 | `>=5.2.1` in test/test_apps/7.2 |
| #69 | webpack-dev-server | npm | MEDIUM | CVE-2025-30360 | `>=5.2.1` in test/test_apps/7.2 |
| #70 | webpack-dev-server | npm | MEDIUM | CVE-2025-30359 | `>=5.2.1` in test/test_apps/8.0 |
| #71 | webpack-dev-server | npm | MEDIUM | CVE-2025-30360 | `>=5.2.1` in test/test_apps/8.0 |
| #72 | webpack-dev-server | npm | MEDIUM | CVE-2025-30359 | `>=5.2.1` in test/test_apps/8.1 |
| #73 | webpack-dev-server | npm | MEDIUM | CVE-2025-30360 | `>=5.2.1` in test/test_apps/8.1 |

### No gem release needed

These changes only affect `devDependencies` in test app `package.json` files. The gem itself is unchanged — no version bump or new release is required.

### Note on full cleanup (future work)

The `webpack-dev-server` entry in these `package.json` files appears to be vestigial — there are no lock files in any test app directory and CI never runs `yarn install`. A follow-up cleanup could remove `webpack-dev-server` from `devDependencies` entirely rather than carrying forward this stale constraint. This PR takes the minimal approach (constraint bump) to close the alerts with the smallest possible diff.

## Test plan

- [x] CI passes (Ruby/Selenium tests unaffected — no JS install step in CI)
- [ ] Dependabot alerts #68–#73 close after merge

🤖 Generated with [Claude Code](https://claude.com/claude-code) using `/dependabot-fix`